### PR TITLE
Remove lastUpdateDateTime field from DTOs and related code.

### DIFF
--- a/devtools_options.yaml
+++ b/devtools_options.yaml
@@ -1,0 +1,3 @@
+description: This file stores settings for Dart & Flutter DevTools.
+documentation: https://docs.flutter.dev/tools/devtools/extensions#configure-extension-enablement-states
+extensions:

--- a/lib/components/animes/anime_component.dart
+++ b/lib/components/animes/anime_component.dart
@@ -45,11 +45,6 @@ class AnimeComponent extends StatelessWidget {
             ImageComponent(
               uuid: anime.uuid,
               type: ImageType.thumbnail,
-              version:
-                  anime.lastUpdateDateTime
-                      .toDateTime()
-                      ?.millisecondsSinceEpoch
-                      .toString(),
               borderRadius: const BorderRadius.all(
                 Radius.circular(Constant.borderRadius),
               ),

--- a/lib/components/animes/calendar/calendar_anime_component.dart
+++ b/lib/components/animes/calendar/calendar_anime_component.dart
@@ -68,13 +68,6 @@ class CalendarAnimeComponent extends StatelessWidget {
                         ? release.mappings!.first.uuid
                         : release.anime.uuid,
                 type: ImageType.banner,
-                version:
-                    (isReleased
-                            ? release.mappings!.first.lastUpdateDateTime
-                            : release.anime.lastUpdateDateTime)
-                        .toDateTime()
-                        ?.millisecondsSinceEpoch
-                        .toString(),
                 borderRadius: const BorderRadius.all(
                   Radius.circular(Constant.borderRadius),
                 ),

--- a/lib/components/animes/followed_anime_component.dart
+++ b/lib/components/animes/followed_anime_component.dart
@@ -4,7 +4,6 @@ import 'package:application/dtos/anime_dto.dart';
 import 'package:application/dtos/enums/image_type.dart';
 import 'package:application/utils/analytics.dart';
 import 'package:application/utils/constant.dart';
-import 'package:application/utils/extensions.dart';
 import 'package:application/views/anime_details_view.dart';
 import 'package:flutter/material.dart';
 
@@ -41,11 +40,6 @@ class FollowedAnimeComponent extends StatelessWidget {
                 ImageComponent(
                   uuid: anime.uuid,
                   type: ImageType.thumbnail,
-                  version:
-                      anime.lastUpdateDateTime
-                          .toDateTime()
-                          ?.millisecondsSinceEpoch
-                          .toString(),
                   // height: 640 / _ratio,
                   borderRadius: const BorderRadius.all(
                     Radius.circular(Constant.borderRadius),

--- a/lib/components/animes/missed/missed_anime_component.dart
+++ b/lib/components/animes/missed/missed_anime_component.dart
@@ -5,7 +5,6 @@ import 'package:application/controllers/animes/anime_controller.dart';
 import 'package:application/dtos/enums/image_type.dart';
 import 'package:application/dtos/missed_anime_dto.dart';
 import 'package:application/utils/analytics.dart';
-import 'package:application/utils/extensions.dart';
 import 'package:application/views/anime_details_view.dart';
 import 'package:flutter/material.dart';
 
@@ -43,11 +42,6 @@ class MissedAnimeComponent extends StatelessWidget {
                 ImageComponent(
                   uuid: missedAnime.anime.uuid,
                   type: ImageType.thumbnail,
-                  version:
-                      missedAnime.anime.lastUpdateDateTime
-                          .toDateTime()
-                          ?.millisecondsSinceEpoch
-                          .toString(),
                   fit: BoxFit.cover,
                   borderRadius: const BorderRadius.all(Radius.circular(360)),
                 ),

--- a/lib/components/episodes/anime_episode_component.dart
+++ b/lib/components/episodes/anime_episode_component.dart
@@ -35,7 +35,6 @@ class AnimeEpisodeComponent extends StatelessWidget {
           Expanded(
             child: EpisodeImage(
               uuid: episode.uuid,
-              lastUpdateDateTime: episode.lastUpdateDateTime,
               platforms: episode.platforms,
               duration: episode.duration,
               borderRadius: const BorderRadius.all(

--- a/lib/components/episodes/episode_image.dart
+++ b/lib/components/episodes/episode_image.dart
@@ -4,13 +4,11 @@ import 'package:application/components/platforms/platform_component.dart';
 import 'package:application/dtos/enums/image_type.dart';
 import 'package:application/dtos/platform_dto.dart';
 import 'package:application/utils/constant.dart';
-import 'package:application/utils/extensions.dart';
 import 'package:flutter/material.dart';
 
 class EpisodeImage extends StatelessWidget {
   const EpisodeImage({
     required this.uuid,
-    required this.lastUpdateDateTime,
     required this.borderRadius,
     super.key,
     this.fit = BoxFit.fill,
@@ -22,7 +20,6 @@ class EpisodeImage extends StatelessWidget {
   });
 
   final String uuid;
-  final String lastUpdateDateTime;
   final List<PlatformDto>? platforms;
   final int? duration;
   final BorderRadius borderRadius;
@@ -37,8 +34,6 @@ class EpisodeImage extends StatelessWidget {
       ImageComponent(
         uuid: uuid,
         type: ImageType.banner,
-        version:
-            lastUpdateDateTime.toDateTime()?.millisecondsSinceEpoch.toString(),
         fit: fit,
         borderRadius: borderRadius,
         width: width,

--- a/lib/components/episodes/followed_episode_component.dart
+++ b/lib/components/episodes/followed_episode_component.dart
@@ -40,7 +40,6 @@ class FollowedEpisodeComponent extends StatelessWidget {
           children: <Widget>[
             EpisodeImage(
               uuid: episode.uuid,
-              lastUpdateDateTime: episode.lastUpdateDateTime,
               platforms: episode.platforms,
               borderRadius: const BorderRadius.all(
                 Radius.circular(Constant.borderRadius),

--- a/lib/components/episodes/grouped_episode_component.dart
+++ b/lib/components/episodes/grouped_episode_component.dart
@@ -36,7 +36,6 @@ class GroupedEpisodeComponent extends StatelessWidget {
       children: <Widget>[
         EpisodeImage(
           uuid: episode.mappings.first,
-          lastUpdateDateTime: episode.lastUpdateDateTime,
           platforms: episode.platforms,
           duration: episode.duration,
           borderRadius: const BorderRadius.all(

--- a/lib/dtos/anime_dto.dart
+++ b/lib/dtos/anime_dto.dart
@@ -15,7 +15,6 @@ sealed class AnimeDto with _$AnimeDto {
     required final String shortName,
     required final String slug,
     required final String releaseDateTime,
-    required final String? lastUpdateDateTime,
     required final String? description,
     required final List<String>? langTypes,
     required final List<SeasonDto>? seasons,

--- a/lib/dtos/anime_dto.freezed.dart
+++ b/lib/dtos/anime_dto.freezed.dart
@@ -16,7 +16,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$AnimeDto {
 
- String get uuid; String get countryCode; String get name; String get shortName; String get slug; String get releaseDateTime; String? get lastUpdateDateTime; String? get description; List<String>? get langTypes; List<SeasonDto>? get seasons; List<AnimePlatformDto>? get platformIds;
+ String get uuid; String get countryCode; String get name; String get shortName; String get slug; String get releaseDateTime; String? get description; List<String>? get langTypes; List<SeasonDto>? get seasons; List<AnimePlatformDto>? get platformIds;
 /// Create a copy of AnimeDto
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -29,16 +29,16 @@ $AnimeDtoCopyWith<AnimeDto> get copyWith => _$AnimeDtoCopyWithImpl<AnimeDto>(thi
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is AnimeDto&&(identical(other.uuid, uuid) || other.uuid == uuid)&&(identical(other.countryCode, countryCode) || other.countryCode == countryCode)&&(identical(other.name, name) || other.name == name)&&(identical(other.shortName, shortName) || other.shortName == shortName)&&(identical(other.slug, slug) || other.slug == slug)&&(identical(other.releaseDateTime, releaseDateTime) || other.releaseDateTime == releaseDateTime)&&(identical(other.lastUpdateDateTime, lastUpdateDateTime) || other.lastUpdateDateTime == lastUpdateDateTime)&&(identical(other.description, description) || other.description == description)&&const DeepCollectionEquality().equals(other.langTypes, langTypes)&&const DeepCollectionEquality().equals(other.seasons, seasons)&&const DeepCollectionEquality().equals(other.platformIds, platformIds));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is AnimeDto&&(identical(other.uuid, uuid) || other.uuid == uuid)&&(identical(other.countryCode, countryCode) || other.countryCode == countryCode)&&(identical(other.name, name) || other.name == name)&&(identical(other.shortName, shortName) || other.shortName == shortName)&&(identical(other.slug, slug) || other.slug == slug)&&(identical(other.releaseDateTime, releaseDateTime) || other.releaseDateTime == releaseDateTime)&&(identical(other.description, description) || other.description == description)&&const DeepCollectionEquality().equals(other.langTypes, langTypes)&&const DeepCollectionEquality().equals(other.seasons, seasons)&&const DeepCollectionEquality().equals(other.platformIds, platformIds));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,uuid,countryCode,name,shortName,slug,releaseDateTime,lastUpdateDateTime,description,const DeepCollectionEquality().hash(langTypes),const DeepCollectionEquality().hash(seasons),const DeepCollectionEquality().hash(platformIds));
+int get hashCode => Object.hash(runtimeType,uuid,countryCode,name,shortName,slug,releaseDateTime,description,const DeepCollectionEquality().hash(langTypes),const DeepCollectionEquality().hash(seasons),const DeepCollectionEquality().hash(platformIds));
 
 @override
 String toString() {
-  return 'AnimeDto(uuid: $uuid, countryCode: $countryCode, name: $name, shortName: $shortName, slug: $slug, releaseDateTime: $releaseDateTime, lastUpdateDateTime: $lastUpdateDateTime, description: $description, langTypes: $langTypes, seasons: $seasons, platformIds: $platformIds)';
+  return 'AnimeDto(uuid: $uuid, countryCode: $countryCode, name: $name, shortName: $shortName, slug: $slug, releaseDateTime: $releaseDateTime, description: $description, langTypes: $langTypes, seasons: $seasons, platformIds: $platformIds)';
 }
 
 
@@ -49,7 +49,7 @@ abstract mixin class $AnimeDtoCopyWith<$Res>  {
   factory $AnimeDtoCopyWith(AnimeDto value, $Res Function(AnimeDto) _then) = _$AnimeDtoCopyWithImpl;
 @useResult
 $Res call({
- String uuid, String countryCode, String name, String shortName, String slug, String releaseDateTime, String? lastUpdateDateTime, String? description, List<String>? langTypes, List<SeasonDto>? seasons, List<AnimePlatformDto>? platformIds
+ String uuid, String countryCode, String name, String shortName, String slug, String releaseDateTime, String? description, List<String>? langTypes, List<SeasonDto>? seasons, List<AnimePlatformDto>? platformIds
 });
 
 
@@ -66,7 +66,7 @@ class _$AnimeDtoCopyWithImpl<$Res>
 
 /// Create a copy of AnimeDto
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? uuid = null,Object? countryCode = null,Object? name = null,Object? shortName = null,Object? slug = null,Object? releaseDateTime = null,Object? lastUpdateDateTime = freezed,Object? description = freezed,Object? langTypes = freezed,Object? seasons = freezed,Object? platformIds = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? uuid = null,Object? countryCode = null,Object? name = null,Object? shortName = null,Object? slug = null,Object? releaseDateTime = null,Object? description = freezed,Object? langTypes = freezed,Object? seasons = freezed,Object? platformIds = freezed,}) {
   return _then(_self.copyWith(
 uuid: null == uuid ? _self.uuid : uuid // ignore: cast_nullable_to_non_nullable
 as String,countryCode: null == countryCode ? _self.countryCode : countryCode // ignore: cast_nullable_to_non_nullable
@@ -74,8 +74,7 @@ as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non
 as String,shortName: null == shortName ? _self.shortName : shortName // ignore: cast_nullable_to_non_nullable
 as String,slug: null == slug ? _self.slug : slug // ignore: cast_nullable_to_non_nullable
 as String,releaseDateTime: null == releaseDateTime ? _self.releaseDateTime : releaseDateTime // ignore: cast_nullable_to_non_nullable
-as String,lastUpdateDateTime: freezed == lastUpdateDateTime ? _self.lastUpdateDateTime : lastUpdateDateTime // ignore: cast_nullable_to_non_nullable
-as String?,description: freezed == description ? _self.description : description // ignore: cast_nullable_to_non_nullable
+as String,description: freezed == description ? _self.description : description // ignore: cast_nullable_to_non_nullable
 as String?,langTypes: freezed == langTypes ? _self.langTypes : langTypes // ignore: cast_nullable_to_non_nullable
 as List<String>?,seasons: freezed == seasons ? _self.seasons : seasons // ignore: cast_nullable_to_non_nullable
 as List<SeasonDto>?,platformIds: freezed == platformIds ? _self.platformIds : platformIds // ignore: cast_nullable_to_non_nullable
@@ -90,7 +89,7 @@ as List<AnimePlatformDto>?,
 @JsonSerializable()
 
 class _AnimeDto implements AnimeDto {
-  const _AnimeDto({required this.uuid, required this.countryCode, required this.name, required this.shortName, required this.slug, required this.releaseDateTime, required this.lastUpdateDateTime, required this.description, required final  List<String>? langTypes, required final  List<SeasonDto>? seasons, required final  List<AnimePlatformDto>? platformIds}): _langTypes = langTypes,_seasons = seasons,_platformIds = platformIds;
+  const _AnimeDto({required this.uuid, required this.countryCode, required this.name, required this.shortName, required this.slug, required this.releaseDateTime, required this.description, required final  List<String>? langTypes, required final  List<SeasonDto>? seasons, required final  List<AnimePlatformDto>? platformIds}): _langTypes = langTypes,_seasons = seasons,_platformIds = platformIds;
   factory _AnimeDto.fromJson(Map<String, dynamic> json) => _$AnimeDtoFromJson(json);
 
 @override final  String uuid;
@@ -99,7 +98,6 @@ class _AnimeDto implements AnimeDto {
 @override final  String shortName;
 @override final  String slug;
 @override final  String releaseDateTime;
-@override final  String? lastUpdateDateTime;
 @override final  String? description;
  final  List<String>? _langTypes;
 @override List<String>? get langTypes {
@@ -142,16 +140,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _AnimeDto&&(identical(other.uuid, uuid) || other.uuid == uuid)&&(identical(other.countryCode, countryCode) || other.countryCode == countryCode)&&(identical(other.name, name) || other.name == name)&&(identical(other.shortName, shortName) || other.shortName == shortName)&&(identical(other.slug, slug) || other.slug == slug)&&(identical(other.releaseDateTime, releaseDateTime) || other.releaseDateTime == releaseDateTime)&&(identical(other.lastUpdateDateTime, lastUpdateDateTime) || other.lastUpdateDateTime == lastUpdateDateTime)&&(identical(other.description, description) || other.description == description)&&const DeepCollectionEquality().equals(other._langTypes, _langTypes)&&const DeepCollectionEquality().equals(other._seasons, _seasons)&&const DeepCollectionEquality().equals(other._platformIds, _platformIds));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _AnimeDto&&(identical(other.uuid, uuid) || other.uuid == uuid)&&(identical(other.countryCode, countryCode) || other.countryCode == countryCode)&&(identical(other.name, name) || other.name == name)&&(identical(other.shortName, shortName) || other.shortName == shortName)&&(identical(other.slug, slug) || other.slug == slug)&&(identical(other.releaseDateTime, releaseDateTime) || other.releaseDateTime == releaseDateTime)&&(identical(other.description, description) || other.description == description)&&const DeepCollectionEquality().equals(other._langTypes, _langTypes)&&const DeepCollectionEquality().equals(other._seasons, _seasons)&&const DeepCollectionEquality().equals(other._platformIds, _platformIds));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,uuid,countryCode,name,shortName,slug,releaseDateTime,lastUpdateDateTime,description,const DeepCollectionEquality().hash(_langTypes),const DeepCollectionEquality().hash(_seasons),const DeepCollectionEquality().hash(_platformIds));
+int get hashCode => Object.hash(runtimeType,uuid,countryCode,name,shortName,slug,releaseDateTime,description,const DeepCollectionEquality().hash(_langTypes),const DeepCollectionEquality().hash(_seasons),const DeepCollectionEquality().hash(_platformIds));
 
 @override
 String toString() {
-  return 'AnimeDto(uuid: $uuid, countryCode: $countryCode, name: $name, shortName: $shortName, slug: $slug, releaseDateTime: $releaseDateTime, lastUpdateDateTime: $lastUpdateDateTime, description: $description, langTypes: $langTypes, seasons: $seasons, platformIds: $platformIds)';
+  return 'AnimeDto(uuid: $uuid, countryCode: $countryCode, name: $name, shortName: $shortName, slug: $slug, releaseDateTime: $releaseDateTime, description: $description, langTypes: $langTypes, seasons: $seasons, platformIds: $platformIds)';
 }
 
 
@@ -162,7 +160,7 @@ abstract mixin class _$AnimeDtoCopyWith<$Res> implements $AnimeDtoCopyWith<$Res>
   factory _$AnimeDtoCopyWith(_AnimeDto value, $Res Function(_AnimeDto) _then) = __$AnimeDtoCopyWithImpl;
 @override @useResult
 $Res call({
- String uuid, String countryCode, String name, String shortName, String slug, String releaseDateTime, String? lastUpdateDateTime, String? description, List<String>? langTypes, List<SeasonDto>? seasons, List<AnimePlatformDto>? platformIds
+ String uuid, String countryCode, String name, String shortName, String slug, String releaseDateTime, String? description, List<String>? langTypes, List<SeasonDto>? seasons, List<AnimePlatformDto>? platformIds
 });
 
 
@@ -179,7 +177,7 @@ class __$AnimeDtoCopyWithImpl<$Res>
 
 /// Create a copy of AnimeDto
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? uuid = null,Object? countryCode = null,Object? name = null,Object? shortName = null,Object? slug = null,Object? releaseDateTime = null,Object? lastUpdateDateTime = freezed,Object? description = freezed,Object? langTypes = freezed,Object? seasons = freezed,Object? platformIds = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? uuid = null,Object? countryCode = null,Object? name = null,Object? shortName = null,Object? slug = null,Object? releaseDateTime = null,Object? description = freezed,Object? langTypes = freezed,Object? seasons = freezed,Object? platformIds = freezed,}) {
   return _then(_AnimeDto(
 uuid: null == uuid ? _self.uuid : uuid // ignore: cast_nullable_to_non_nullable
 as String,countryCode: null == countryCode ? _self.countryCode : countryCode // ignore: cast_nullable_to_non_nullable
@@ -187,8 +185,7 @@ as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non
 as String,shortName: null == shortName ? _self.shortName : shortName // ignore: cast_nullable_to_non_nullable
 as String,slug: null == slug ? _self.slug : slug // ignore: cast_nullable_to_non_nullable
 as String,releaseDateTime: null == releaseDateTime ? _self.releaseDateTime : releaseDateTime // ignore: cast_nullable_to_non_nullable
-as String,lastUpdateDateTime: freezed == lastUpdateDateTime ? _self.lastUpdateDateTime : lastUpdateDateTime // ignore: cast_nullable_to_non_nullable
-as String?,description: freezed == description ? _self.description : description // ignore: cast_nullable_to_non_nullable
+as String,description: freezed == description ? _self.description : description // ignore: cast_nullable_to_non_nullable
 as String?,langTypes: freezed == langTypes ? _self._langTypes : langTypes // ignore: cast_nullable_to_non_nullable
 as List<String>?,seasons: freezed == seasons ? _self._seasons : seasons // ignore: cast_nullable_to_non_nullable
 as List<SeasonDto>?,platformIds: freezed == platformIds ? _self._platformIds : platformIds // ignore: cast_nullable_to_non_nullable

--- a/lib/dtos/anime_dto.g.dart
+++ b/lib/dtos/anime_dto.g.dart
@@ -13,7 +13,6 @@ _AnimeDto _$AnimeDtoFromJson(Map<String, dynamic> json) => _AnimeDto(
   shortName: json['shortName'] as String,
   slug: json['slug'] as String,
   releaseDateTime: json['releaseDateTime'] as String,
-  lastUpdateDateTime: json['lastUpdateDateTime'] as String?,
   description: json['description'] as String?,
   langTypes:
       (json['langTypes'] as List<dynamic>?)?.map((e) => e as String).toList(),
@@ -34,7 +33,6 @@ Map<String, dynamic> _$AnimeDtoToJson(_AnimeDto instance) => <String, dynamic>{
   'shortName': instance.shortName,
   'slug': instance.slug,
   'releaseDateTime': instance.releaseDateTime,
-  'lastUpdateDateTime': instance.lastUpdateDateTime,
   'description': instance.description,
   'langTypes': instance.langTypes,
   'seasons': instance.seasons,

--- a/lib/dtos/episode_mapping_dto.dart
+++ b/lib/dtos/episode_mapping_dto.dart
@@ -12,7 +12,6 @@ sealed class EpisodeMappingDto with _$EpisodeMappingDto {
     required final String uuid,
     required final AnimeDto? anime,
     required final String releaseDateTime,
-    required final String lastUpdateDateTime,
     required final int season,
     required final String episodeType,
     required final int number,

--- a/lib/dtos/episode_mapping_dto.freezed.dart
+++ b/lib/dtos/episode_mapping_dto.freezed.dart
@@ -16,7 +16,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$EpisodeMappingDto {
 
- String get uuid; AnimeDto? get anime; String get releaseDateTime; String get lastUpdateDateTime; int get season; String get episodeType; int get number; int get duration; String? get title; String? get description; List<EpisodeVariantDto>? get variants; List<PlatformDto>? get platforms; List<String>? get langTypes;
+ String get uuid; AnimeDto? get anime; String get releaseDateTime; int get season; String get episodeType; int get number; int get duration; String? get title; String? get description; List<EpisodeVariantDto>? get variants; List<PlatformDto>? get platforms; List<String>? get langTypes;
 /// Create a copy of EpisodeMappingDto
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -29,16 +29,16 @@ $EpisodeMappingDtoCopyWith<EpisodeMappingDto> get copyWith => _$EpisodeMappingDt
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is EpisodeMappingDto&&(identical(other.uuid, uuid) || other.uuid == uuid)&&(identical(other.anime, anime) || other.anime == anime)&&(identical(other.releaseDateTime, releaseDateTime) || other.releaseDateTime == releaseDateTime)&&(identical(other.lastUpdateDateTime, lastUpdateDateTime) || other.lastUpdateDateTime == lastUpdateDateTime)&&(identical(other.season, season) || other.season == season)&&(identical(other.episodeType, episodeType) || other.episodeType == episodeType)&&(identical(other.number, number) || other.number == number)&&(identical(other.duration, duration) || other.duration == duration)&&(identical(other.title, title) || other.title == title)&&(identical(other.description, description) || other.description == description)&&const DeepCollectionEquality().equals(other.variants, variants)&&const DeepCollectionEquality().equals(other.platforms, platforms)&&const DeepCollectionEquality().equals(other.langTypes, langTypes));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is EpisodeMappingDto&&(identical(other.uuid, uuid) || other.uuid == uuid)&&(identical(other.anime, anime) || other.anime == anime)&&(identical(other.releaseDateTime, releaseDateTime) || other.releaseDateTime == releaseDateTime)&&(identical(other.season, season) || other.season == season)&&(identical(other.episodeType, episodeType) || other.episodeType == episodeType)&&(identical(other.number, number) || other.number == number)&&(identical(other.duration, duration) || other.duration == duration)&&(identical(other.title, title) || other.title == title)&&(identical(other.description, description) || other.description == description)&&const DeepCollectionEquality().equals(other.variants, variants)&&const DeepCollectionEquality().equals(other.platforms, platforms)&&const DeepCollectionEquality().equals(other.langTypes, langTypes));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,uuid,anime,releaseDateTime,lastUpdateDateTime,season,episodeType,number,duration,title,description,const DeepCollectionEquality().hash(variants),const DeepCollectionEquality().hash(platforms),const DeepCollectionEquality().hash(langTypes));
+int get hashCode => Object.hash(runtimeType,uuid,anime,releaseDateTime,season,episodeType,number,duration,title,description,const DeepCollectionEquality().hash(variants),const DeepCollectionEquality().hash(platforms),const DeepCollectionEquality().hash(langTypes));
 
 @override
 String toString() {
-  return 'EpisodeMappingDto(uuid: $uuid, anime: $anime, releaseDateTime: $releaseDateTime, lastUpdateDateTime: $lastUpdateDateTime, season: $season, episodeType: $episodeType, number: $number, duration: $duration, title: $title, description: $description, variants: $variants, platforms: $platforms, langTypes: $langTypes)';
+  return 'EpisodeMappingDto(uuid: $uuid, anime: $anime, releaseDateTime: $releaseDateTime, season: $season, episodeType: $episodeType, number: $number, duration: $duration, title: $title, description: $description, variants: $variants, platforms: $platforms, langTypes: $langTypes)';
 }
 
 
@@ -49,7 +49,7 @@ abstract mixin class $EpisodeMappingDtoCopyWith<$Res>  {
   factory $EpisodeMappingDtoCopyWith(EpisodeMappingDto value, $Res Function(EpisodeMappingDto) _then) = _$EpisodeMappingDtoCopyWithImpl;
 @useResult
 $Res call({
- String uuid, AnimeDto? anime, String releaseDateTime, String lastUpdateDateTime, int season, String episodeType, int number, int duration, String? title, String? description, List<EpisodeVariantDto>? variants, List<PlatformDto>? platforms, List<String>? langTypes
+ String uuid, AnimeDto? anime, String releaseDateTime, int season, String episodeType, int number, int duration, String? title, String? description, List<EpisodeVariantDto>? variants, List<PlatformDto>? platforms, List<String>? langTypes
 });
 
 
@@ -66,12 +66,11 @@ class _$EpisodeMappingDtoCopyWithImpl<$Res>
 
 /// Create a copy of EpisodeMappingDto
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? uuid = null,Object? anime = freezed,Object? releaseDateTime = null,Object? lastUpdateDateTime = null,Object? season = null,Object? episodeType = null,Object? number = null,Object? duration = null,Object? title = freezed,Object? description = freezed,Object? variants = freezed,Object? platforms = freezed,Object? langTypes = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? uuid = null,Object? anime = freezed,Object? releaseDateTime = null,Object? season = null,Object? episodeType = null,Object? number = null,Object? duration = null,Object? title = freezed,Object? description = freezed,Object? variants = freezed,Object? platforms = freezed,Object? langTypes = freezed,}) {
   return _then(_self.copyWith(
 uuid: null == uuid ? _self.uuid : uuid // ignore: cast_nullable_to_non_nullable
 as String,anime: freezed == anime ? _self.anime : anime // ignore: cast_nullable_to_non_nullable
 as AnimeDto?,releaseDateTime: null == releaseDateTime ? _self.releaseDateTime : releaseDateTime // ignore: cast_nullable_to_non_nullable
-as String,lastUpdateDateTime: null == lastUpdateDateTime ? _self.lastUpdateDateTime : lastUpdateDateTime // ignore: cast_nullable_to_non_nullable
 as String,season: null == season ? _self.season : season // ignore: cast_nullable_to_non_nullable
 as int,episodeType: null == episodeType ? _self.episodeType : episodeType // ignore: cast_nullable_to_non_nullable
 as String,number: null == number ? _self.number : number // ignore: cast_nullable_to_non_nullable
@@ -104,13 +103,12 @@ $AnimeDtoCopyWith<$Res>? get anime {
 @JsonSerializable()
 
 class _EpisodeMappingDto implements EpisodeMappingDto {
-  const _EpisodeMappingDto({required this.uuid, required this.anime, required this.releaseDateTime, required this.lastUpdateDateTime, required this.season, required this.episodeType, required this.number, required this.duration, required this.title, required this.description, required final  List<EpisodeVariantDto>? variants, required final  List<PlatformDto>? platforms, required final  List<String>? langTypes}): _variants = variants,_platforms = platforms,_langTypes = langTypes;
+  const _EpisodeMappingDto({required this.uuid, required this.anime, required this.releaseDateTime, required this.season, required this.episodeType, required this.number, required this.duration, required this.title, required this.description, required final  List<EpisodeVariantDto>? variants, required final  List<PlatformDto>? platforms, required final  List<String>? langTypes}): _variants = variants,_platforms = platforms,_langTypes = langTypes;
   factory _EpisodeMappingDto.fromJson(Map<String, dynamic> json) => _$EpisodeMappingDtoFromJson(json);
 
 @override final  String uuid;
 @override final  AnimeDto? anime;
 @override final  String releaseDateTime;
-@override final  String lastUpdateDateTime;
 @override final  int season;
 @override final  String episodeType;
 @override final  int number;
@@ -158,16 +156,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _EpisodeMappingDto&&(identical(other.uuid, uuid) || other.uuid == uuid)&&(identical(other.anime, anime) || other.anime == anime)&&(identical(other.releaseDateTime, releaseDateTime) || other.releaseDateTime == releaseDateTime)&&(identical(other.lastUpdateDateTime, lastUpdateDateTime) || other.lastUpdateDateTime == lastUpdateDateTime)&&(identical(other.season, season) || other.season == season)&&(identical(other.episodeType, episodeType) || other.episodeType == episodeType)&&(identical(other.number, number) || other.number == number)&&(identical(other.duration, duration) || other.duration == duration)&&(identical(other.title, title) || other.title == title)&&(identical(other.description, description) || other.description == description)&&const DeepCollectionEquality().equals(other._variants, _variants)&&const DeepCollectionEquality().equals(other._platforms, _platforms)&&const DeepCollectionEquality().equals(other._langTypes, _langTypes));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _EpisodeMappingDto&&(identical(other.uuid, uuid) || other.uuid == uuid)&&(identical(other.anime, anime) || other.anime == anime)&&(identical(other.releaseDateTime, releaseDateTime) || other.releaseDateTime == releaseDateTime)&&(identical(other.season, season) || other.season == season)&&(identical(other.episodeType, episodeType) || other.episodeType == episodeType)&&(identical(other.number, number) || other.number == number)&&(identical(other.duration, duration) || other.duration == duration)&&(identical(other.title, title) || other.title == title)&&(identical(other.description, description) || other.description == description)&&const DeepCollectionEquality().equals(other._variants, _variants)&&const DeepCollectionEquality().equals(other._platforms, _platforms)&&const DeepCollectionEquality().equals(other._langTypes, _langTypes));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,uuid,anime,releaseDateTime,lastUpdateDateTime,season,episodeType,number,duration,title,description,const DeepCollectionEquality().hash(_variants),const DeepCollectionEquality().hash(_platforms),const DeepCollectionEquality().hash(_langTypes));
+int get hashCode => Object.hash(runtimeType,uuid,anime,releaseDateTime,season,episodeType,number,duration,title,description,const DeepCollectionEquality().hash(_variants),const DeepCollectionEquality().hash(_platforms),const DeepCollectionEquality().hash(_langTypes));
 
 @override
 String toString() {
-  return 'EpisodeMappingDto(uuid: $uuid, anime: $anime, releaseDateTime: $releaseDateTime, lastUpdateDateTime: $lastUpdateDateTime, season: $season, episodeType: $episodeType, number: $number, duration: $duration, title: $title, description: $description, variants: $variants, platforms: $platforms, langTypes: $langTypes)';
+  return 'EpisodeMappingDto(uuid: $uuid, anime: $anime, releaseDateTime: $releaseDateTime, season: $season, episodeType: $episodeType, number: $number, duration: $duration, title: $title, description: $description, variants: $variants, platforms: $platforms, langTypes: $langTypes)';
 }
 
 
@@ -178,7 +176,7 @@ abstract mixin class _$EpisodeMappingDtoCopyWith<$Res> implements $EpisodeMappin
   factory _$EpisodeMappingDtoCopyWith(_EpisodeMappingDto value, $Res Function(_EpisodeMappingDto) _then) = __$EpisodeMappingDtoCopyWithImpl;
 @override @useResult
 $Res call({
- String uuid, AnimeDto? anime, String releaseDateTime, String lastUpdateDateTime, int season, String episodeType, int number, int duration, String? title, String? description, List<EpisodeVariantDto>? variants, List<PlatformDto>? platforms, List<String>? langTypes
+ String uuid, AnimeDto? anime, String releaseDateTime, int season, String episodeType, int number, int duration, String? title, String? description, List<EpisodeVariantDto>? variants, List<PlatformDto>? platforms, List<String>? langTypes
 });
 
 
@@ -195,12 +193,11 @@ class __$EpisodeMappingDtoCopyWithImpl<$Res>
 
 /// Create a copy of EpisodeMappingDto
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? uuid = null,Object? anime = freezed,Object? releaseDateTime = null,Object? lastUpdateDateTime = null,Object? season = null,Object? episodeType = null,Object? number = null,Object? duration = null,Object? title = freezed,Object? description = freezed,Object? variants = freezed,Object? platforms = freezed,Object? langTypes = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? uuid = null,Object? anime = freezed,Object? releaseDateTime = null,Object? season = null,Object? episodeType = null,Object? number = null,Object? duration = null,Object? title = freezed,Object? description = freezed,Object? variants = freezed,Object? platforms = freezed,Object? langTypes = freezed,}) {
   return _then(_EpisodeMappingDto(
 uuid: null == uuid ? _self.uuid : uuid // ignore: cast_nullable_to_non_nullable
 as String,anime: freezed == anime ? _self.anime : anime // ignore: cast_nullable_to_non_nullable
 as AnimeDto?,releaseDateTime: null == releaseDateTime ? _self.releaseDateTime : releaseDateTime // ignore: cast_nullable_to_non_nullable
-as String,lastUpdateDateTime: null == lastUpdateDateTime ? _self.lastUpdateDateTime : lastUpdateDateTime // ignore: cast_nullable_to_non_nullable
 as String,season: null == season ? _self.season : season // ignore: cast_nullable_to_non_nullable
 as int,episodeType: null == episodeType ? _self.episodeType : episodeType // ignore: cast_nullable_to_non_nullable
 as String,number: null == number ? _self.number : number // ignore: cast_nullable_to_non_nullable

--- a/lib/dtos/episode_mapping_dto.g.dart
+++ b/lib/dtos/episode_mapping_dto.g.dart
@@ -15,7 +15,6 @@ _EpisodeMappingDto _$EpisodeMappingDtoFromJson(
           ? null
           : AnimeDto.fromJson(json['anime'] as Map<String, dynamic>),
   releaseDateTime: json['releaseDateTime'] as String,
-  lastUpdateDateTime: json['lastUpdateDateTime'] as String,
   season: (json['season'] as num).toInt(),
   episodeType: json['episodeType'] as String,
   number: (json['number'] as num).toInt(),
@@ -39,7 +38,6 @@ Map<String, dynamic> _$EpisodeMappingDtoToJson(_EpisodeMappingDto instance) =>
       'uuid': instance.uuid,
       'anime': instance.anime,
       'releaseDateTime': instance.releaseDateTime,
-      'lastUpdateDateTime': instance.lastUpdateDateTime,
       'season': instance.season,
       'episodeType': instance.episodeType,
       'number': instance.number,

--- a/lib/dtos/grouped_episode_dto.dart
+++ b/lib/dtos/grouped_episode_dto.dart
@@ -11,7 +11,6 @@ sealed class GroupedEpisodeDto with _$GroupedEpisodeDto {
     required final AnimeDto anime,
     required final List<PlatformDto> platforms,
     required final String releaseDateTime,
-    required final String lastUpdateDateTime,
     required final String season,
     required final String episodeType,
     required final String number,

--- a/lib/dtos/grouped_episode_dto.freezed.dart
+++ b/lib/dtos/grouped_episode_dto.freezed.dart
@@ -16,7 +16,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$GroupedEpisodeDto {
 
- AnimeDto get anime; List<PlatformDto> get platforms; String get releaseDateTime; String get lastUpdateDateTime; String get season; String get episodeType; String get number; List<String> get langTypes; String? get title; String? get description; int? get duration; List<String> get mappings; List<String> get urls;
+ AnimeDto get anime; List<PlatformDto> get platforms; String get releaseDateTime; String get season; String get episodeType; String get number; List<String> get langTypes; String? get title; String? get description; int? get duration; List<String> get mappings; List<String> get urls;
 /// Create a copy of GroupedEpisodeDto
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -29,16 +29,16 @@ $GroupedEpisodeDtoCopyWith<GroupedEpisodeDto> get copyWith => _$GroupedEpisodeDt
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is GroupedEpisodeDto&&(identical(other.anime, anime) || other.anime == anime)&&const DeepCollectionEquality().equals(other.platforms, platforms)&&(identical(other.releaseDateTime, releaseDateTime) || other.releaseDateTime == releaseDateTime)&&(identical(other.lastUpdateDateTime, lastUpdateDateTime) || other.lastUpdateDateTime == lastUpdateDateTime)&&(identical(other.season, season) || other.season == season)&&(identical(other.episodeType, episodeType) || other.episodeType == episodeType)&&(identical(other.number, number) || other.number == number)&&const DeepCollectionEquality().equals(other.langTypes, langTypes)&&(identical(other.title, title) || other.title == title)&&(identical(other.description, description) || other.description == description)&&(identical(other.duration, duration) || other.duration == duration)&&const DeepCollectionEquality().equals(other.mappings, mappings)&&const DeepCollectionEquality().equals(other.urls, urls));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is GroupedEpisodeDto&&(identical(other.anime, anime) || other.anime == anime)&&const DeepCollectionEquality().equals(other.platforms, platforms)&&(identical(other.releaseDateTime, releaseDateTime) || other.releaseDateTime == releaseDateTime)&&(identical(other.season, season) || other.season == season)&&(identical(other.episodeType, episodeType) || other.episodeType == episodeType)&&(identical(other.number, number) || other.number == number)&&const DeepCollectionEquality().equals(other.langTypes, langTypes)&&(identical(other.title, title) || other.title == title)&&(identical(other.description, description) || other.description == description)&&(identical(other.duration, duration) || other.duration == duration)&&const DeepCollectionEquality().equals(other.mappings, mappings)&&const DeepCollectionEquality().equals(other.urls, urls));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,anime,const DeepCollectionEquality().hash(platforms),releaseDateTime,lastUpdateDateTime,season,episodeType,number,const DeepCollectionEquality().hash(langTypes),title,description,duration,const DeepCollectionEquality().hash(mappings),const DeepCollectionEquality().hash(urls));
+int get hashCode => Object.hash(runtimeType,anime,const DeepCollectionEquality().hash(platforms),releaseDateTime,season,episodeType,number,const DeepCollectionEquality().hash(langTypes),title,description,duration,const DeepCollectionEquality().hash(mappings),const DeepCollectionEquality().hash(urls));
 
 @override
 String toString() {
-  return 'GroupedEpisodeDto(anime: $anime, platforms: $platforms, releaseDateTime: $releaseDateTime, lastUpdateDateTime: $lastUpdateDateTime, season: $season, episodeType: $episodeType, number: $number, langTypes: $langTypes, title: $title, description: $description, duration: $duration, mappings: $mappings, urls: $urls)';
+  return 'GroupedEpisodeDto(anime: $anime, platforms: $platforms, releaseDateTime: $releaseDateTime, season: $season, episodeType: $episodeType, number: $number, langTypes: $langTypes, title: $title, description: $description, duration: $duration, mappings: $mappings, urls: $urls)';
 }
 
 
@@ -49,7 +49,7 @@ abstract mixin class $GroupedEpisodeDtoCopyWith<$Res>  {
   factory $GroupedEpisodeDtoCopyWith(GroupedEpisodeDto value, $Res Function(GroupedEpisodeDto) _then) = _$GroupedEpisodeDtoCopyWithImpl;
 @useResult
 $Res call({
- AnimeDto anime, List<PlatformDto> platforms, String releaseDateTime, String lastUpdateDateTime, String season, String episodeType, String number, List<String> langTypes, String? title, String? description, int? duration, List<String> mappings, List<String> urls
+ AnimeDto anime, List<PlatformDto> platforms, String releaseDateTime, String season, String episodeType, String number, List<String> langTypes, String? title, String? description, int? duration, List<String> mappings, List<String> urls
 });
 
 
@@ -66,12 +66,11 @@ class _$GroupedEpisodeDtoCopyWithImpl<$Res>
 
 /// Create a copy of GroupedEpisodeDto
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? anime = null,Object? platforms = null,Object? releaseDateTime = null,Object? lastUpdateDateTime = null,Object? season = null,Object? episodeType = null,Object? number = null,Object? langTypes = null,Object? title = freezed,Object? description = freezed,Object? duration = freezed,Object? mappings = null,Object? urls = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? anime = null,Object? platforms = null,Object? releaseDateTime = null,Object? season = null,Object? episodeType = null,Object? number = null,Object? langTypes = null,Object? title = freezed,Object? description = freezed,Object? duration = freezed,Object? mappings = null,Object? urls = null,}) {
   return _then(_self.copyWith(
 anime: null == anime ? _self.anime : anime // ignore: cast_nullable_to_non_nullable
 as AnimeDto,platforms: null == platforms ? _self.platforms : platforms // ignore: cast_nullable_to_non_nullable
 as List<PlatformDto>,releaseDateTime: null == releaseDateTime ? _self.releaseDateTime : releaseDateTime // ignore: cast_nullable_to_non_nullable
-as String,lastUpdateDateTime: null == lastUpdateDateTime ? _self.lastUpdateDateTime : lastUpdateDateTime // ignore: cast_nullable_to_non_nullable
 as String,season: null == season ? _self.season : season // ignore: cast_nullable_to_non_nullable
 as String,episodeType: null == episodeType ? _self.episodeType : episodeType // ignore: cast_nullable_to_non_nullable
 as String,number: null == number ? _self.number : number // ignore: cast_nullable_to_non_nullable
@@ -101,7 +100,7 @@ $AnimeDtoCopyWith<$Res> get anime {
 @JsonSerializable()
 
 class _GroupedEpisodeDto implements GroupedEpisodeDto {
-  const _GroupedEpisodeDto({required this.anime, required final  List<PlatformDto> platforms, required this.releaseDateTime, required this.lastUpdateDateTime, required this.season, required this.episodeType, required this.number, required final  List<String> langTypes, required this.title, required this.description, required this.duration, required final  List<String> mappings, required final  List<String> urls}): _platforms = platforms,_langTypes = langTypes,_mappings = mappings,_urls = urls;
+  const _GroupedEpisodeDto({required this.anime, required final  List<PlatformDto> platforms, required this.releaseDateTime, required this.season, required this.episodeType, required this.number, required final  List<String> langTypes, required this.title, required this.description, required this.duration, required final  List<String> mappings, required final  List<String> urls}): _platforms = platforms,_langTypes = langTypes,_mappings = mappings,_urls = urls;
   factory _GroupedEpisodeDto.fromJson(Map<String, dynamic> json) => _$GroupedEpisodeDtoFromJson(json);
 
 @override final  AnimeDto anime;
@@ -113,7 +112,6 @@ class _GroupedEpisodeDto implements GroupedEpisodeDto {
 }
 
 @override final  String releaseDateTime;
-@override final  String lastUpdateDateTime;
 @override final  String season;
 @override final  String episodeType;
 @override final  String number;
@@ -155,16 +153,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _GroupedEpisodeDto&&(identical(other.anime, anime) || other.anime == anime)&&const DeepCollectionEquality().equals(other._platforms, _platforms)&&(identical(other.releaseDateTime, releaseDateTime) || other.releaseDateTime == releaseDateTime)&&(identical(other.lastUpdateDateTime, lastUpdateDateTime) || other.lastUpdateDateTime == lastUpdateDateTime)&&(identical(other.season, season) || other.season == season)&&(identical(other.episodeType, episodeType) || other.episodeType == episodeType)&&(identical(other.number, number) || other.number == number)&&const DeepCollectionEquality().equals(other._langTypes, _langTypes)&&(identical(other.title, title) || other.title == title)&&(identical(other.description, description) || other.description == description)&&(identical(other.duration, duration) || other.duration == duration)&&const DeepCollectionEquality().equals(other._mappings, _mappings)&&const DeepCollectionEquality().equals(other._urls, _urls));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _GroupedEpisodeDto&&(identical(other.anime, anime) || other.anime == anime)&&const DeepCollectionEquality().equals(other._platforms, _platforms)&&(identical(other.releaseDateTime, releaseDateTime) || other.releaseDateTime == releaseDateTime)&&(identical(other.season, season) || other.season == season)&&(identical(other.episodeType, episodeType) || other.episodeType == episodeType)&&(identical(other.number, number) || other.number == number)&&const DeepCollectionEquality().equals(other._langTypes, _langTypes)&&(identical(other.title, title) || other.title == title)&&(identical(other.description, description) || other.description == description)&&(identical(other.duration, duration) || other.duration == duration)&&const DeepCollectionEquality().equals(other._mappings, _mappings)&&const DeepCollectionEquality().equals(other._urls, _urls));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,anime,const DeepCollectionEquality().hash(_platforms),releaseDateTime,lastUpdateDateTime,season,episodeType,number,const DeepCollectionEquality().hash(_langTypes),title,description,duration,const DeepCollectionEquality().hash(_mappings),const DeepCollectionEquality().hash(_urls));
+int get hashCode => Object.hash(runtimeType,anime,const DeepCollectionEquality().hash(_platforms),releaseDateTime,season,episodeType,number,const DeepCollectionEquality().hash(_langTypes),title,description,duration,const DeepCollectionEquality().hash(_mappings),const DeepCollectionEquality().hash(_urls));
 
 @override
 String toString() {
-  return 'GroupedEpisodeDto(anime: $anime, platforms: $platforms, releaseDateTime: $releaseDateTime, lastUpdateDateTime: $lastUpdateDateTime, season: $season, episodeType: $episodeType, number: $number, langTypes: $langTypes, title: $title, description: $description, duration: $duration, mappings: $mappings, urls: $urls)';
+  return 'GroupedEpisodeDto(anime: $anime, platforms: $platforms, releaseDateTime: $releaseDateTime, season: $season, episodeType: $episodeType, number: $number, langTypes: $langTypes, title: $title, description: $description, duration: $duration, mappings: $mappings, urls: $urls)';
 }
 
 
@@ -175,7 +173,7 @@ abstract mixin class _$GroupedEpisodeDtoCopyWith<$Res> implements $GroupedEpisod
   factory _$GroupedEpisodeDtoCopyWith(_GroupedEpisodeDto value, $Res Function(_GroupedEpisodeDto) _then) = __$GroupedEpisodeDtoCopyWithImpl;
 @override @useResult
 $Res call({
- AnimeDto anime, List<PlatformDto> platforms, String releaseDateTime, String lastUpdateDateTime, String season, String episodeType, String number, List<String> langTypes, String? title, String? description, int? duration, List<String> mappings, List<String> urls
+ AnimeDto anime, List<PlatformDto> platforms, String releaseDateTime, String season, String episodeType, String number, List<String> langTypes, String? title, String? description, int? duration, List<String> mappings, List<String> urls
 });
 
 
@@ -192,12 +190,11 @@ class __$GroupedEpisodeDtoCopyWithImpl<$Res>
 
 /// Create a copy of GroupedEpisodeDto
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? anime = null,Object? platforms = null,Object? releaseDateTime = null,Object? lastUpdateDateTime = null,Object? season = null,Object? episodeType = null,Object? number = null,Object? langTypes = null,Object? title = freezed,Object? description = freezed,Object? duration = freezed,Object? mappings = null,Object? urls = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? anime = null,Object? platforms = null,Object? releaseDateTime = null,Object? season = null,Object? episodeType = null,Object? number = null,Object? langTypes = null,Object? title = freezed,Object? description = freezed,Object? duration = freezed,Object? mappings = null,Object? urls = null,}) {
   return _then(_GroupedEpisodeDto(
 anime: null == anime ? _self.anime : anime // ignore: cast_nullable_to_non_nullable
 as AnimeDto,platforms: null == platforms ? _self._platforms : platforms // ignore: cast_nullable_to_non_nullable
 as List<PlatformDto>,releaseDateTime: null == releaseDateTime ? _self.releaseDateTime : releaseDateTime // ignore: cast_nullable_to_non_nullable
-as String,lastUpdateDateTime: null == lastUpdateDateTime ? _self.lastUpdateDateTime : lastUpdateDateTime // ignore: cast_nullable_to_non_nullable
 as String,season: null == season ? _self.season : season // ignore: cast_nullable_to_non_nullable
 as String,episodeType: null == episodeType ? _self.episodeType : episodeType // ignore: cast_nullable_to_non_nullable
 as String,number: null == number ? _self.number : number // ignore: cast_nullable_to_non_nullable

--- a/lib/dtos/grouped_episode_dto.g.dart
+++ b/lib/dtos/grouped_episode_dto.g.dart
@@ -14,7 +14,6 @@ _GroupedEpisodeDto _$GroupedEpisodeDtoFromJson(Map<String, dynamic> json) =>
               .map((e) => PlatformDto.fromJson(e as Map<String, dynamic>))
               .toList(),
       releaseDateTime: json['releaseDateTime'] as String,
-      lastUpdateDateTime: json['lastUpdateDateTime'] as String,
       season: json['season'] as String,
       episodeType: json['episodeType'] as String,
       number: json['number'] as String,
@@ -33,7 +32,6 @@ Map<String, dynamic> _$GroupedEpisodeDtoToJson(_GroupedEpisodeDto instance) =>
       'anime': instance.anime,
       'platforms': instance.platforms,
       'releaseDateTime': instance.releaseDateTime,
-      'lastUpdateDateTime': instance.lastUpdateDateTime,
       'season': instance.season,
       'episodeType': instance.episodeType,
       'number': instance.number,

--- a/lib/views/anime_details_view.dart
+++ b/lib/views/anime_details_view.dart
@@ -20,7 +20,6 @@ import 'package:application/dtos/season_dto.dart';
 import 'package:application/l10n/app_localizations.dart';
 import 'package:application/utils/analytics.dart';
 import 'package:application/utils/constant.dart';
-import 'package:application/utils/extensions.dart';
 import 'package:application/utils/widget_builder.dart' as wb;
 import 'package:flutter/material.dart';
 import 'package:share_plus/share_plus.dart';
@@ -133,11 +132,6 @@ class _AnimeDetailsViewState extends State<AnimeDetailsView> {
                         ImageComponent(
                           uuid: widget.anime.uuid,
                           type: ImageType.banner,
-                          version:
-                              widget.anime.lastUpdateDateTime
-                                  .toDateTime()
-                                  ?.millisecondsSinceEpoch
-                                  .toString(),
                           height:
                               MediaQuery.sizeOf(context).width > 900
                                   ? 300


### PR DESCRIPTION
The `lastUpdateDateTime` field was removed from various DTOs (e.g., AnimeDto, GroupedEpisodeDto) and related components to simplify data structures. Code adjustments were made to ensure compatibility, including removing unused extensions and redundant references.