### PR TITLE
Refactor HTTP request handling and update member login API.

### DIFF
--- a/lib/controllers/member_controller.dart
+++ b/lib/controllers/member_controller.dart
@@ -106,13 +106,13 @@ class MemberController {
     final PackageInfo packageInfo = await PackageInfo.fromPlatform();
 
     final Response response = await HttpRequest.instance.post(
-      '/v2/members/login',
-      body: jsonEncode(<String, String>{
-        'identifier': identifier,
-        'appVersion': '${packageInfo.version}+${packageInfo.buildNumber}',
-        'device': _device,
-        'locale': Platform.localeName,
-      }),
+      '/v1/members/login',
+      headers: <String, String>{
+        'X-App-Version': '${packageInfo.version}+${packageInfo.buildNumber}',
+        'X-Device': _device,
+        'X-Locale': Platform.localeName,
+      },
+      body: identifier,
     );
 
     if (response.statusCode == HttpStatus.notFound) {

--- a/lib/utils/http_request.dart
+++ b/lib/utils/http_request.dart
@@ -15,11 +15,9 @@ class HttpRequest {
     final String? token,
     final VoidCallback? onUnauthorized,
   }) async {
-    final Map<String, String> headers = <String, String>{};
-
-    if (token != null) {
-      headers['Authorization'] = 'Bearer $token';
-    }
+    final Map<String, String> headers = <String, String>{
+      if (token != null) 'Authorization': 'Bearer $token',
+    };
 
     final http.Response response = await http
         .get(Uri.parse(Constant.apiUrl + endpoint), headers: headers)
@@ -55,20 +53,19 @@ class HttpRequest {
   Future<http.Response> post<Response>(
     final String endpoint, {
     final String? token,
+    final Map<String, String>? headers,
     final Object? body,
   }) async {
-    final Map<String, String> headers = <String, String>{
+    final Map<String, String> requestHeaders = <String, String>{
       'Content-Type': 'application/json',
+      if (token != null) 'Authorization': 'Bearer $token',
+      if (headers != null) ...headers,
     };
-
-    if (token != null) {
-      headers['Authorization'] = 'Bearer $token';
-    }
 
     return http
         .post(
           Uri.parse(Constant.apiUrl + endpoint),
-          headers: headers,
+          headers: requestHeaders,
           body: body,
         )
         .timeout(_timeout);


### PR DESCRIPTION
Simplified header construction in HTTP methods with `if` conditions. Modified member login to use consistent headers and updated API endpoint from `/v2/members/login` to `/v1/members/login`.