### PR TITLE
Integrate Firebase Messaging and handle background notification events

### DIFF
--- a/lib/controllers/shared_preferences_controller.dart
+++ b/lib/controllers/shared_preferences_controller.dart
@@ -5,9 +5,15 @@ class SharedPreferencesController {
   static final SharedPreferencesController instance =
       SharedPreferencesController();
   late final SharedPreferences _sharedPreferences;
+  bool _isInitialized = false;
 
   Future<void> init() async {
+    if (_isInitialized) {
+      return;
+    }
+
     _sharedPreferences = await SharedPreferences.getInstance();
+    _isInitialized = true;
   }
 
   bool containsKey(final ConfigPropertyKey key) =>

--- a/lib/dtos/enums/config_property_key.dart
+++ b/lib/dtos/enums/config_property_key.dart
@@ -4,4 +4,5 @@ enum ConfigPropertyKey {
   oldIdentifier,
   reviewAppLaunched,
   sortType,
+  lastApiCallNotification,
 }


### PR DESCRIPTION
Added support for Firebase Messaging by registering `onBackgroundMessage` and `onMessage` listeners in `main.dart`. Implemented `_firebaseMessagingBackgroundHandler` to process background notifications, including daily API call checks and updates to shared preferences. Updated `ConfigPropertyKey` and `SharedPreferencesController` to store and manage notification data.