### PR TITLE
Add `NotificationThrottler` for background notification throttling

### DIFF
--- a/.github/workflows/global_workflow.yml
+++ b/.github/workflows/global_workflow.yml
@@ -16,3 +16,4 @@ jobs:
       - run: flutter pub get
       - run: dart analyze . --fatal-infos --fatal-warnings
       - run: dart format --set-exit-if-changed .
+      - run: flutter test

--- a/lib/utils/constant.dart
+++ b/lib/utils/constant.dart
@@ -10,6 +10,13 @@ class Constant {
   static const String defaultText = '＞︿＜';
   static const double cornerPadding = 7.5;
 
+  /// Nombre maximum d'envois au serveur par jour déclenchés via notifications.
+  ///
+  /// 1 = au plus un envoi par jour (par défaut)
+  /// 2 = au plus deux envois par jour, espacés d'environ 12 heures
+  /// 3 ou plus = envois répartis uniformément sur 24h
+  static const int maxServerSendsPerDay = 1;
+
   static bool get isAndroidOrIOS =>
       defaultTargetPlatform == TargetPlatform.android ||
       defaultTargetPlatform == TargetPlatform.iOS;

--- a/lib/utils/notification_throttler.dart
+++ b/lib/utils/notification_throttler.dart
@@ -1,0 +1,86 @@
+import 'package:application/controllers/shared_preferences_controller.dart';
+import 'package:application/dtos/enums/config_property_key.dart';
+import 'package:application/utils/constant.dart';
+
+/// FR: Fourni un mécanisme de limitation (throttling) des appels serveur
+/// déclenchés par les notifications en arrière-plan. La journée est divisée
+/// en créneaux temporels de durée égale, calculés à partir de
+/// [Constant.maxServerSendsPerDay]. Un seul envoi est autorisé par créneau.
+///
+/// EN: Provides throttling for background notification-triggered server calls.
+/// The day is divided into evenly spaced time slots based on
+/// [Constant.maxServerSendsPerDay]. A call is allowed at most once per slot.
+///
+/// Examples / Exemples:
+/// - 1 (par défaut): au plus un envoi par jour / one call per day at most
+/// - 2: jusqu'à deux envois par jour, espacés d'environ 12h / up to two calls ~12h apart
+/// - 3+ : envois uniformément répartis sur 24h / calls evenly spread over 24h
+///
+/// Storage / Stockage:
+/// - Last successful send timestamp stored as ISO8601 in
+///   [ConfigPropertyKey.lastApiCallNotification].
+class NotificationThrottler {
+  NotificationThrottler._();
+
+  /// Returns true if a server call should be throttled right now, i.e.,
+  /// a call has already been performed within the current time slot today.
+  static bool isCallThrottled() =>
+      isCallThrottledWithMax(Constant.maxServerSendsPerDay);
+
+  /// Variante testable permettant d'injecter [maxPerDay] et une date [now].
+  /// Identique à [isCallThrottled] lorsque [maxPerDay] vaut
+  /// [Constant.maxServerSendsPerDay] et que [now] est omis.
+  static bool isCallThrottledWithMax(final int maxPerDay, {DateTime? now}) {
+    if (maxPerDay <= 0) {
+      // Non-positive configuration disables calls entirely.
+      return true;
+    }
+
+    final String? lastApiCallNotification = SharedPreferencesController.instance
+        .getString(ConfigPropertyKey.lastApiCallNotification);
+
+    now ??= DateTime.now();
+    final DateTime today = DateTime(now.year, now.month, now.day);
+
+    // Compute the slot length (in seconds) by evenly splitting the day.
+    const int dayInSeconds = 24 * 60 * 60;
+    final int slotLengthSec = (dayInSeconds ~/ maxPerDay).clamp(
+      1,
+      dayInSeconds,
+    );
+
+    final int secondsSinceMidnight = now.difference(today).inSeconds;
+    final int currentSlot = (secondsSinceMidnight ~/ slotLengthSec).clamp(
+      0,
+      maxPerDay - 1,
+    );
+
+    if (lastApiCallNotification == null) {
+      // Never called before: allow.
+      return false;
+    }
+
+    final DateTime lastApiCallNotificationDate = DateTime.parse(
+      lastApiCallNotification,
+    );
+
+    final DateTime lastCallDay = DateTime(
+      lastApiCallNotificationDate.year,
+      lastApiCallNotificationDate.month,
+      lastApiCallNotificationDate.day,
+    );
+
+    if (!lastCallDay.isAtSameMomentAs(today)) {
+      // Last call was on another day: allow.
+      return false;
+    }
+
+    final int lastSecondsSinceMidnight = lastApiCallNotificationDate
+        .difference(today)
+        .inSeconds;
+    final int lastSlot = lastSecondsSinceMidnight ~/ slotLengthSec;
+
+    // Throttle if last call was performed in the same slot as now.
+    return lastSlot == currentSlot;
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -476,7 +476,7 @@ packages:
     source: hosted
     version: "2.0.30"
   flutter_test:
-    dependency: transitive
+    dependency: "direct dev"
     description: flutter
     source: sdk
     version: "0.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,6 +40,8 @@ dev_dependencies:
   flutter_launcher_icons: ^0.14.4
   flutter_lints: ^6.0.0
   flutter_native_splash: ^2.4.6
+  flutter_test:
+    sdk: flutter
   freezed: ^3.2.3
   json_serializable: ^6.11.1
 

--- a/test/utils/notification_throttler_test.dart
+++ b/test/utils/notification_throttler_test.dart
@@ -1,0 +1,122 @@
+import 'package:application/controllers/shared_preferences_controller.dart';
+import 'package:application/dtos/enums/config_property_key.dart';
+import 'package:application/utils/notification_throttler.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  setUpAll(() async {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+    await SharedPreferencesController.instance.init();
+  });
+
+  tearDown(() async {
+    // Clear the last call between tests to avoid leakage.
+    await SharedPreferencesController.instance.remove(
+      ConfigPropertyKey.lastApiCallNotification,
+    );
+  });
+
+  group('NotificationThrottler with maxPerDay = 2 (slots ~12h)', () {
+    test('No previous call today => not throttled', () {
+      final DateTime now = DateTime(2025, 1, 1, 10);
+      final bool throttled = NotificationThrottler.isCallThrottledWithMax(
+        2,
+        now: now,
+      );
+      expect(throttled, isFalse);
+    });
+
+    test('Previous call in same slot => throttled', () async {
+      final DateTime now = DateTime(2025, 1, 1, 10); // slot 0 (00:00-11:59)
+      final DateTime previous = DateTime(2025, 1, 1, 9); // same slot 0
+
+      await SharedPreferencesController.instance.setString(
+        ConfigPropertyKey.lastApiCallNotification,
+        previous.toIso8601String(),
+      );
+
+      final bool throttled = NotificationThrottler.isCallThrottledWithMax(
+        2,
+        now: now,
+      );
+      expect(throttled, isTrue);
+    });
+
+    test('Previous call in different slot => not throttled', () async {
+      final DateTime now = DateTime(2025, 1, 1, 20); // slot 1 (12:00-23:59)
+      final DateTime previous = DateTime(2025, 1, 1, 10); // slot 0
+
+      await SharedPreferencesController.instance.setString(
+        ConfigPropertyKey.lastApiCallNotification,
+        previous.toIso8601String(),
+      );
+
+      final bool throttled = NotificationThrottler.isCallThrottledWithMax(
+        2,
+        now: now,
+      );
+      expect(throttled, isFalse);
+    });
+  });
+
+  group('NotificationThrottler with maxPerDay = 3 (slots ~8h)', () {
+    test('No previous call today => not throttled', () {
+      final DateTime now = DateTime(2025, 1, 1, 10); // slot 1
+      final bool throttled = NotificationThrottler.isCallThrottledWithMax(
+        3,
+        now: now,
+      );
+      expect(throttled, isFalse);
+    });
+
+    test('Previous call in same slot => throttled', () async {
+      final DateTime now = DateTime(2025, 1, 1, 10); // slot 1 (08:00-15:59)
+      final DateTime previous = DateTime(2025, 1, 1, 12); // same slot 1
+
+      await SharedPreferencesController.instance.setString(
+        ConfigPropertyKey.lastApiCallNotification,
+        previous.toIso8601String(),
+      );
+
+      final bool throttled = NotificationThrottler.isCallThrottledWithMax(
+        3,
+        now: now,
+      );
+      expect(throttled, isTrue);
+    });
+
+    test('Previous call in different slot => not throttled', () async {
+      final DateTime now = DateTime(2025, 1, 1, 10); // slot 1
+      final DateTime previous = DateTime(2025, 1, 1, 2); // slot 0
+
+      await SharedPreferencesController.instance.setString(
+        ConfigPropertyKey.lastApiCallNotification,
+        previous.toIso8601String(),
+      );
+
+      final bool throttled = NotificationThrottler.isCallThrottledWithMax(
+        3,
+        now: now,
+      );
+      expect(throttled, isFalse);
+    });
+
+    test('Previous day => not throttled', () async {
+      final DateTime now = DateTime(2025, 1, 1, 10); // any slot
+      final DateTime previous = DateTime(2024, 12, 31, 22);
+
+      await SharedPreferencesController.instance.setString(
+        ConfigPropertyKey.lastApiCallNotification,
+        previous.toIso8601String(),
+      );
+
+      final bool throttled = NotificationThrottler.isCallThrottledWithMax(
+        3,
+        now: now,
+      );
+      expect(throttled, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
Introduced `NotificationThrottler` in `notification_throttler.dart` to limit server calls triggered by background notifications. Implemented daily throttling mechanism based on evenly distributed time slots. Updated `main.dart` to utilize `NotificationThrottler` and refactored related logic for better readability. Added `maxServerSendsPerDay` constant in `constant.dart` for configuration.