### PR TITLE
Introduce platform preference management and reordering feature

### DIFF
--- a/lib/components/animes/calendar/calendar_anime_component.dart
+++ b/lib/components/animes/calendar/calendar_anime_component.dart
@@ -166,7 +166,7 @@ class CalendarAnimeComponent extends StatelessWidget {
                               style: Theme.of(context).cardButtonStyle,
                             ),
                             WatchButton(
-                              url: release.mappings!.first.variants!.first.url,
+                              sources: release.mappings!.first.sources,
                               simple: true,
                             ),
                           ],

--- a/lib/components/episodes/anime_episode_component.dart
+++ b/lib/components/episodes/anime_episode_component.dart
@@ -4,6 +4,7 @@ import 'package:application/components/episodes/episode_image.dart';
 import 'package:application/components/episodes/episode_information_component.dart';
 import 'package:application/components/lang_type_component.dart';
 import 'package:application/dtos/episode_mapping_dto.dart';
+import 'package:application/dtos/episode_source_dto.dart';
 import 'package:application/utils/constant.dart';
 import 'package:flutter/material.dart';
 
@@ -35,7 +36,10 @@ class AnimeEpisodeComponent extends StatelessWidget {
           Expanded(
             child: EpisodeImage(
               uuid: episode.uuid,
-              platforms: episode.platforms,
+              platforms: episode.sources
+                  .map((final EpisodeSourceDto source) => source.platform)
+                  .toSet()
+                  .toList(),
               duration: episode.duration,
               borderRadius: const BorderRadius.all(
                 Radius.circular(Constant.borderRadius),
@@ -60,15 +64,18 @@ class AnimeEpisodeComponent extends StatelessWidget {
                   number: episode.number.toString(),
                   showSeason: false,
                 ),
-                ...?episode.langTypes?.map(
-                  (final String langType) =>
-                      LangTypeComponent(langType: langType),
-                ),
+                ...episode.sources
+                    .map((final EpisodeSourceDto source) => source.langType)
+                    .toSet()
+                    .map(
+                      (final String langType) =>
+                          LangTypeComponent(langType: langType),
+                    ),
                 const Spacer(),
                 EpisodeActionBar(
+                  sources: episode.sources,
                   anime: episode.anime!.uuid,
                   episode: episode.uuid,
-                  url: episode.variants!.first.url,
                   simple: true,
                 ),
               ],

--- a/lib/components/episodes/episode_action_bar.dart
+++ b/lib/components/episodes/episode_action_bar.dart
@@ -1,11 +1,12 @@
 import 'package:application/components/watch_button.dart';
 import 'package:application/components/watchlist_button.dart';
+import 'package:application/dtos/episode_source_dto.dart';
 import 'package:application/utils/extensions.dart';
 import 'package:flutter/material.dart';
 
 class EpisodeActionBar extends StatelessWidget {
   const EpisodeActionBar({
-    required this.url,
+    required this.sources,
     super.key,
     this.anime,
     this.episode,
@@ -13,9 +14,9 @@ class EpisodeActionBar extends StatelessWidget {
     this.showWatchlist = true,
   });
 
+  final List<EpisodeSourceDto> sources;
   final String? anime;
   final String? episode;
-  final String url;
   final bool simple;
   final bool showWatchlist;
 
@@ -32,7 +33,7 @@ class EpisodeActionBar extends StatelessWidget {
           simple: simple,
           style: Theme.of(context).cardButtonStyle,
         ),
-      WatchButton(url: url, simple: simple),
+      WatchButton(sources: sources, simple: simple),
     ],
   );
 }

--- a/lib/components/episodes/followed_episode_component.dart
+++ b/lib/components/episodes/followed_episode_component.dart
@@ -1,6 +1,7 @@
 import 'package:application/components/episodes/episode_image.dart';
 import 'package:application/components/episodes/episode_information_component.dart';
 import 'package:application/dtos/episode_mapping_dto.dart';
+import 'package:application/dtos/episode_source_dto.dart';
 import 'package:application/utils/analytics.dart';
 import 'package:application/utils/constant.dart';
 import 'package:application/views/anime_details_view.dart';
@@ -39,7 +40,10 @@ class FollowedEpisodeComponent extends StatelessWidget {
           children: <Widget>[
             EpisodeImage(
               uuid: episode.uuid,
-              platforms: episode.platforms,
+              platforms: episode.sources
+                  .map((final EpisodeSourceDto source) => source.platform)
+                  .toSet()
+                  .toList(),
               borderRadius: const BorderRadius.all(
                 Radius.circular(Constant.borderRadius),
               ),

--- a/lib/components/episodes/grouped_episode_component.dart
+++ b/lib/components/episodes/grouped_episode_component.dart
@@ -4,6 +4,7 @@ import 'package:application/components/episodes/episode_image.dart';
 import 'package:application/components/episodes/episode_information_component.dart';
 import 'package:application/components/lang_type_component.dart';
 import 'package:application/controllers/episodes/episode_controller.dart';
+import 'package:application/dtos/episode_source_dto.dart';
 import 'package:application/dtos/grouped_episode_dto.dart';
 import 'package:application/utils/analytics.dart';
 import 'package:application/utils/constant.dart';
@@ -35,7 +36,10 @@ class GroupedEpisodeComponent extends StatelessWidget {
       children: <Widget>[
         EpisodeImage(
           uuid: episode.mappings.first,
-          platforms: episode.platforms,
+          platforms: episode.sources
+              .map((final EpisodeSourceDto source) => source.platform)
+              .toSet()
+              .toList(),
           duration: episode.duration,
           borderRadius: const BorderRadius.all(
             Radius.circular(Constant.borderRadius),
@@ -54,14 +58,18 @@ class GroupedEpisodeComponent extends StatelessWidget {
           episodeType: episode.episodeType,
           number: episode.number,
         ),
-        ...episode.langTypes.map(
-          (final String langType) => LangTypeComponent(langType: langType),
-        ),
+        ...episode.sources
+            .map((final EpisodeSourceDto source) => source.langType)
+            .toSet()
+            .toList()
+            .map(
+              (final String langType) => LangTypeComponent(langType: langType),
+            ),
         const SizedBox(height: 8),
         EpisodeActionBar(
+          sources: episode.sources,
           anime: episode.anime.uuid,
           episode: episode.mappings.length == 1 ? episode.mappings.first : null,
-          url: episode.urls.first,
           showWatchlist: episode.mappings.length == 1,
         ),
       ],

--- a/lib/components/platforms/platform_component.dart
+++ b/lib/components/platforms/platform_component.dart
@@ -5,9 +5,16 @@ import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 
 class PlatformComponent extends StatelessWidget {
-  const PlatformComponent({required this.platform, super.key});
+  const PlatformComponent({
+    required this.platform,
+    this.width = 16,
+    this.height = 16,
+    super.key,
+  });
 
   final PlatformDto platform;
+  final double width;
+  final double height;
 
   @override
   Widget build(final BuildContext context) => ClipRRect(
@@ -16,13 +23,13 @@ class PlatformComponent extends StatelessWidget {
       imageUrl: '${Constant.baseUrl}/assets/img/platforms/${platform.image}',
       filterQuality: FilterQuality.high,
       fit: BoxFit.cover,
-      width: 16,
-      height: 16,
+      width: width,
+      height: height,
       placeholder: (final BuildContext context, final String url) =>
-          Container(color: Colors.grey, width: 16, height: 16),
+          Container(color: Colors.grey, width: width, height: height),
       errorWidget:
           (final BuildContext context, final String url, final dynamic error) =>
-              Container(color: Colors.grey, width: 16, height: 16),
+              Container(color: Colors.grey, width: width, height: height),
       fadeInDuration: Duration.zero,
       fadeOutDuration: Duration.zero,
     ),

--- a/lib/components/platforms/platform_preference_dialog.dart
+++ b/lib/components/platforms/platform_preference_dialog.dart
@@ -1,0 +1,167 @@
+import 'package:application/components/platforms/platform_component.dart';
+import 'package:application/dtos/platform_dto.dart';
+import 'package:application/l10n/app_localizations.dart';
+import 'package:flutter/material.dart';
+
+class PlatformPreferenceResult {
+  PlatformPreferenceResult({
+    required this.orderedPlatforms,
+    required this.remember,
+  });
+  final List<PlatformDto> orderedPlatforms;
+  final bool remember;
+}
+
+class PlatformPreferenceDialog extends StatefulWidget {
+  const PlatformPreferenceDialog({
+    required this.platforms,
+    this.initialRemember = false,
+    this.isForSettings = false,
+    super.key,
+  });
+
+  final List<PlatformDto> platforms;
+  final bool initialRemember;
+  final bool isForSettings;
+
+  static Future<PlatformPreferenceResult?> show(
+    final BuildContext context, {
+    required final List<PlatformDto> platforms,
+    final bool initialRemember = false,
+    final bool isForSettings = false,
+  }) => showModalBottomSheet<PlatformPreferenceResult>(
+    context: context,
+    isScrollControlled: true,
+    showDragHandle: true,
+    builder: (final BuildContext context) => FractionallySizedBox(
+      heightFactor: 0.55,
+      child: PlatformPreferenceDialog(
+        platforms: platforms,
+        initialRemember: initialRemember,
+        isForSettings: isForSettings,
+      ),
+    ),
+  );
+
+  @override
+  State<PlatformPreferenceDialog> createState() =>
+      _PlatformPreferenceDialogState();
+}
+
+class _PlatformPreferenceDialogState extends State<PlatformPreferenceDialog> {
+  late List<PlatformDto> _platforms;
+  late bool _remember;
+
+  @override
+  void initState() {
+    super.initState();
+    _platforms = List<PlatformDto>.from(widget.platforms);
+    _remember = widget.initialRemember;
+  }
+
+  @override
+  Widget build(final BuildContext context) {
+    final AppLocalizations l10n = AppLocalizations.of(context)!;
+
+    return SafeArea(
+      child: Scaffold(
+        body: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Padding(
+              padding: const EdgeInsets.all(16),
+              child: Text(
+                l10n.platformPreferencesDescription,
+                style: Theme.of(context).textTheme.bodyMedium,
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              child: Text(
+                l10n.dragToReorder,
+                style: Theme.of(context).textTheme.bodyMedium,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Expanded(
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                child: ReorderableListView.builder(
+                  itemBuilder: (final BuildContext context, final int index) {
+                    final PlatformDto platform = _platforms[index];
+
+                    return Padding(
+                      key: ValueKey<String>(platform.id),
+                      padding: const EdgeInsets.symmetric(vertical: 8),
+                      child: Row(
+                        spacing: 8,
+                        children: <Widget>[
+                          PlatformComponent(
+                            platform: platform,
+                            width: 24,
+                            height: 24,
+                          ),
+                          Text(
+                            platform.name,
+                            style: Theme.of(context).textTheme.bodyLarge,
+                          ),
+                          const Spacer(),
+                          const Icon(Icons.drag_handle),
+                        ],
+                      ),
+                    );
+                  },
+                  itemCount: _platforms.length,
+                  onReorder: (final int oldIndex, int newIndex) {
+                    setState(() {
+                      if (newIndex > oldIndex) {
+                        newIndex -= 1;
+                      }
+                      final PlatformDto item = _platforms.removeAt(oldIndex);
+                      _platforms.insert(newIndex, item);
+                    });
+                  },
+                ),
+              ),
+            ),
+            if (!widget.isForSettings)
+              Padding(
+                padding: const EdgeInsets.all(16),
+                child: Row(
+                  children: <Widget>[
+                    Checkbox(
+                      value: _remember,
+                      onChanged: (final bool? value) =>
+                          setState(() => _remember = value ?? false),
+                    ),
+                    const SizedBox(width: 8),
+                    Expanded(child: Text(l10n.rememberMyChoice)),
+                  ],
+                ),
+              ),
+            Padding(
+              padding: const EdgeInsets.only(left: 16, right: 16, bottom: 16),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.end,
+                children: <Widget>[
+                  ElevatedButton(
+                    onPressed: () =>
+                        Navigator.of(context).pop<PlatformPreferenceResult>(
+                          PlatformPreferenceResult(
+                            orderedPlatforms: _platforms,
+                            remember: widget.isForSettings || _remember,
+                          ),
+                        ),
+                    child: Text(
+                      widget.isForSettings ? l10n.save : l10n.continueLabel,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/components/watch_button.dart
+++ b/lib/components/watch_button.dart
@@ -1,21 +1,19 @@
+import 'package:application/controllers/platforms_controller.dart';
+import 'package:application/dtos/episode_source_dto.dart';
 import 'package:application/l10n/app_localizations.dart';
 import 'package:application/utils/extensions.dart';
 import 'package:flutter/material.dart';
-import 'package:url_launcher/url_launcher.dart';
 
 class WatchButton extends StatelessWidget {
-  const WatchButton({required this.url, super.key, this.simple = false});
+  const WatchButton({required this.sources, super.key, this.simple = false});
 
-  final String url;
+  final List<EpisodeSourceDto> sources;
   final bool simple;
 
   @override
   Widget build(final BuildContext context) => ElevatedButton(
     style: Theme.of(context).cardButtonStyle,
-    onPressed: () => launchUrl(
-      Uri.parse(url),
-      mode: LaunchMode.externalNonBrowserApplication,
-    ),
+    onPressed: () => PlatformsController.instance.handleWatch(context, sources),
     child: Flex(
       spacing: 8,
       direction: Axis.horizontal,

--- a/lib/controllers/platforms_controller.dart
+++ b/lib/controllers/platforms_controller.dart
@@ -1,0 +1,184 @@
+import 'dart:async';
+
+import 'package:application/components/platforms/platform_preference_dialog.dart';
+import 'package:application/controllers/generic_controller.dart';
+import 'package:application/controllers/shared_preferences_controller.dart';
+import 'package:application/dtos/enums/config_property_key.dart';
+import 'package:application/dtos/episode_source_dto.dart';
+import 'package:application/dtos/platform_dto.dart';
+import 'package:application/utils/http_request.dart';
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+class PlatformsController extends GenericController<PlatformDto> {
+  PlatformsController() : super(addScrollListener: false);
+
+  static final PlatformsController instance = PlatformsController();
+  static const int _unrankedIndex = 1 << 20;
+
+  @override
+  Future<Iterable<PlatformDto>> fetchItems() async {
+    final List<dynamic> data = await HttpRequest.instance.get<List<dynamic>>(
+      '/v1/platforms',
+    );
+
+    final List<PlatformDto> platforms = data
+        .map(
+          (final dynamic e) => PlatformDto.fromJson(e as Map<String, dynamic>),
+        )
+        .toList();
+
+    return platforms;
+  }
+
+  Future<List<PlatformDto>> managePlatformPreferences(
+    final BuildContext context,
+    final List<PlatformDto> items, {
+    final bool isForSettings = false,
+  }) async {
+    final List<PlatformDto> platforms = _sort<PlatformDto>(
+      items,
+      (final PlatformDto p) => p.id,
+    );
+    final PlatformPreferenceResult? result =
+        await PlatformPreferenceDialog.show(
+          context,
+          platforms: platforms,
+          initialRemember: _isRememberEnabled(),
+          isForSettings: isForSettings,
+        );
+    if (result == null) {
+      return <PlatformDto>[];
+    }
+    await _savePreferenceOrderAndRemember(
+      result.orderedPlatforms,
+      result.remember,
+    );
+    return result.orderedPlatforms;
+  }
+
+  Future<void> handleWatch(
+    final BuildContext context,
+    final List<EpisodeSourceDto> sources,
+  ) async {
+    if (sources.isEmpty) {
+      return;
+    }
+
+    if (_isRememberEnabled()) {
+      final List<EpisodeSourceDto> sorted = _sort<EpisodeSourceDto>(
+        sources,
+        (final EpisodeSourceDto s) => s.platform.id,
+      );
+      await _launch(sorted.first.url);
+      return;
+    }
+
+    final List<PlatformDto> platforms = _preparePlatformsFromSources(sources);
+
+    if (platforms.length == 1) {
+      final EpisodeSourceDto selected = sources.firstWhere(
+        (final EpisodeSourceDto s) => s.platform.id == platforms.first.id,
+        orElse: () => sources.first,
+      );
+      await _launch(selected.url);
+      return;
+    }
+
+    final PlatformPreferenceResult? result =
+        await PlatformPreferenceDialog.show(
+          context,
+          platforms: platforms,
+          initialRemember: _isRememberEnabled(),
+        );
+
+    if (result == null) {
+      return;
+    }
+
+    if (result.remember) {
+      await _savePreferenceOrderAndRemember(result.orderedPlatforms, true);
+    }
+
+    final String selectedId = result.orderedPlatforms.first.id;
+    final EpisodeSourceDto selected = sources.firstWhere(
+      (final EpisodeSourceDto s) => s.platform.id == selectedId,
+      orElse: () => sources.first,
+    );
+    await _launch(selected.url);
+  }
+
+  List<T> _sort<T>(
+    final List<T> list,
+    final String Function(T item) idExtractor,
+  ) {
+    final Map<String, int> index = _buildOrderIndex();
+    final List<T> copy = List<T>.from(list)
+      ..sort((final T a, final T b) {
+        final int ai = index[idExtractor(a)] ?? _unrankedIndex;
+        final int bi = index[idExtractor(b)] ?? _unrankedIndex;
+        return ai.compareTo(bi);
+      });
+    return copy;
+  }
+
+  List<PlatformDto> _preparePlatformsFromSources(
+    final List<EpisodeSourceDto> sources,
+  ) {
+    final Map<String, EpisodeSourceDto> byId = <String, EpisodeSourceDto>{};
+    for (final EpisodeSourceDto s in sources) {
+      byId.putIfAbsent(s.platform.id, () => s);
+    }
+    final List<PlatformDto> uniquePlatforms = byId.values
+        .map((final EpisodeSourceDto e) => e.platform)
+        .toList();
+    return _sort<PlatformDto>(uniquePlatforms, (final PlatformDto p) => p.id);
+  }
+
+  Map<String, int> _buildOrderIndex() {
+    final List<String> order = _getSavedOrderIds();
+    return <String, int>{for (int i = 0; i < order.length; i++) order[i]: i};
+  }
+
+  List<String> _getSavedOrderIds() {
+    final String? orderStr = SharedPreferencesController.instance.getString(
+      ConfigPropertyKey.platformOrder,
+    );
+    if (orderStr == null || orderStr.isEmpty) {
+      return <String>[];
+    }
+    return orderStr
+        .split(',')
+        .map((final String e) => e.trim())
+        .where((final String e) => e.isNotEmpty)
+        .toList();
+  }
+
+  bool _isRememberEnabled() => SharedPreferencesController.instance.getBool(
+    ConfigPropertyKey.rememberPlatformChoice,
+  );
+
+  Future<void> _savePreferenceOrderAndRemember(
+    final List<PlatformDto> ordered,
+    final bool remember,
+  ) async {
+    final String newOrder = ordered
+        .map((final PlatformDto p) => p.id)
+        .join(',');
+    await SharedPreferencesController.instance.setString(
+      ConfigPropertyKey.platformOrder,
+      newOrder,
+    );
+    await SharedPreferencesController.instance.setBool(
+      ConfigPropertyKey.rememberPlatformChoice,
+      remember,
+    );
+  }
+
+  Future<void> _launch(final String url) async {
+    await launchUrl(
+      Uri.parse(url),
+      mode: LaunchMode.externalNonBrowserApplication,
+    );
+  }
+}

--- a/lib/dtos/anime_dto.freezed.dart
+++ b/lib/dtos/anime_dto.freezed.dart
@@ -1,6 +1,5 @@
-// dart format width=80
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -84,6 +83,130 @@ as List<AnimePlatformDto>?,
 
 }
 
+
+/// Adds pattern-matching-related methods to [AnimeDto].
+extension AnimeDtoPatterns on AnimeDto {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _AnimeDto value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _AnimeDto() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _AnimeDto value)  $default,){
+final _that = this;
+switch (_that) {
+case _AnimeDto():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _AnimeDto value)?  $default,){
+final _that = this;
+switch (_that) {
+case _AnimeDto() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String uuid,  String countryCode,  String name,  String shortName,  String slug,  String releaseDateTime,  String? description,  List<String>? langTypes,  List<SeasonDto>? seasons,  List<AnimePlatformDto>? platformIds)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _AnimeDto() when $default != null:
+return $default(_that.uuid,_that.countryCode,_that.name,_that.shortName,_that.slug,_that.releaseDateTime,_that.description,_that.langTypes,_that.seasons,_that.platformIds);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String uuid,  String countryCode,  String name,  String shortName,  String slug,  String releaseDateTime,  String? description,  List<String>? langTypes,  List<SeasonDto>? seasons,  List<AnimePlatformDto>? platformIds)  $default,) {final _that = this;
+switch (_that) {
+case _AnimeDto():
+return $default(_that.uuid,_that.countryCode,_that.name,_that.shortName,_that.slug,_that.releaseDateTime,_that.description,_that.langTypes,_that.seasons,_that.platformIds);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String uuid,  String countryCode,  String name,  String shortName,  String slug,  String releaseDateTime,  String? description,  List<String>? langTypes,  List<SeasonDto>? seasons,  List<AnimePlatformDto>? platformIds)?  $default,) {final _that = this;
+switch (_that) {
+case _AnimeDto() when $default != null:
+return $default(_that.uuid,_that.countryCode,_that.name,_that.shortName,_that.slug,_that.releaseDateTime,_that.description,_that.langTypes,_that.seasons,_that.platformIds);case _:
+  return null;
+
+}
+}
+
+}
 
 /// @nodoc
 @JsonSerializable()

--- a/lib/dtos/anime_platform_dto.freezed.dart
+++ b/lib/dtos/anime_platform_dto.freezed.dart
@@ -1,6 +1,5 @@
-// dart format width=80
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -86,6 +85,130 @@ $PlatformDtoCopyWith<$Res> get platform {
 }
 }
 
+
+/// Adds pattern-matching-related methods to [AnimePlatformDto].
+extension AnimePlatformDtoPatterns on AnimePlatformDto {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _AnimePlatformDto value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _AnimePlatformDto() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _AnimePlatformDto value)  $default,){
+final _that = this;
+switch (_that) {
+case _AnimePlatformDto():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _AnimePlatformDto value)?  $default,){
+final _that = this;
+switch (_that) {
+case _AnimePlatformDto() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String uuid,  PlatformDto platform,  String platformId)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _AnimePlatformDto() when $default != null:
+return $default(_that.uuid,_that.platform,_that.platformId);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String uuid,  PlatformDto platform,  String platformId)  $default,) {final _that = this;
+switch (_that) {
+case _AnimePlatformDto():
+return $default(_that.uuid,_that.platform,_that.platformId);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String uuid,  PlatformDto platform,  String platformId)?  $default,) {final _that = this;
+switch (_that) {
+case _AnimePlatformDto() when $default != null:
+return $default(_that.uuid,_that.platform,_that.platformId);case _:
+  return null;
+
+}
+}
+
+}
 
 /// @nodoc
 @JsonSerializable()

--- a/lib/dtos/enums/config_property_key.dart
+++ b/lib/dtos/enums/config_property_key.dart
@@ -5,4 +5,6 @@ enum ConfigPropertyKey {
   reviewAppLaunched,
   sortType,
   lastApiCallNotification,
+  platformOrder,
+  rememberPlatformChoice,
 }

--- a/lib/dtos/episode_mapping_dto.dart
+++ b/lib/dtos/episode_mapping_dto.dart
@@ -1,6 +1,5 @@
 import 'package:application/dtos/anime_dto.dart';
-import 'package:application/dtos/episode_variant_dto.dart';
-import 'package:application/dtos/platform_dto.dart';
+import 'package:application/dtos/episode_source_dto.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'episode_mapping_dto.freezed.dart';
@@ -18,9 +17,7 @@ sealed class EpisodeMappingDto with _$EpisodeMappingDto {
     required final int duration,
     required final String? title,
     required final String? description,
-    required final List<EpisodeVariantDto>? variants,
-    required final List<PlatformDto> platforms,
-    required final List<String>? langTypes,
+    required final List<EpisodeSourceDto> sources,
   }) = _EpisodeMappingDto;
 
   factory EpisodeMappingDto.fromJson(final Map<String, dynamic> json) =>

--- a/lib/dtos/episode_mapping_dto.freezed.dart
+++ b/lib/dtos/episode_mapping_dto.freezed.dart
@@ -1,6 +1,5 @@
-// dart format width=80
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -16,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$EpisodeMappingDto {
 
- String get uuid; AnimeDto? get anime; String get releaseDateTime; int get season; String get episodeType; int get number; int get duration; String? get title; String? get description; List<EpisodeVariantDto>? get variants; List<PlatformDto> get platforms; List<String>? get langTypes;
+ String get uuid; AnimeDto? get anime; String get releaseDateTime; int get season; String get episodeType; int get number; int get duration; String? get title; String? get description; List<EpisodeSourceDto> get sources;
 /// Create a copy of EpisodeMappingDto
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -29,16 +28,16 @@ $EpisodeMappingDtoCopyWith<EpisodeMappingDto> get copyWith => _$EpisodeMappingDt
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is EpisodeMappingDto&&(identical(other.uuid, uuid) || other.uuid == uuid)&&(identical(other.anime, anime) || other.anime == anime)&&(identical(other.releaseDateTime, releaseDateTime) || other.releaseDateTime == releaseDateTime)&&(identical(other.season, season) || other.season == season)&&(identical(other.episodeType, episodeType) || other.episodeType == episodeType)&&(identical(other.number, number) || other.number == number)&&(identical(other.duration, duration) || other.duration == duration)&&(identical(other.title, title) || other.title == title)&&(identical(other.description, description) || other.description == description)&&const DeepCollectionEquality().equals(other.variants, variants)&&const DeepCollectionEquality().equals(other.platforms, platforms)&&const DeepCollectionEquality().equals(other.langTypes, langTypes));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is EpisodeMappingDto&&(identical(other.uuid, uuid) || other.uuid == uuid)&&(identical(other.anime, anime) || other.anime == anime)&&(identical(other.releaseDateTime, releaseDateTime) || other.releaseDateTime == releaseDateTime)&&(identical(other.season, season) || other.season == season)&&(identical(other.episodeType, episodeType) || other.episodeType == episodeType)&&(identical(other.number, number) || other.number == number)&&(identical(other.duration, duration) || other.duration == duration)&&(identical(other.title, title) || other.title == title)&&(identical(other.description, description) || other.description == description)&&const DeepCollectionEquality().equals(other.sources, sources));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,uuid,anime,releaseDateTime,season,episodeType,number,duration,title,description,const DeepCollectionEquality().hash(variants),const DeepCollectionEquality().hash(platforms),const DeepCollectionEquality().hash(langTypes));
+int get hashCode => Object.hash(runtimeType,uuid,anime,releaseDateTime,season,episodeType,number,duration,title,description,const DeepCollectionEquality().hash(sources));
 
 @override
 String toString() {
-  return 'EpisodeMappingDto(uuid: $uuid, anime: $anime, releaseDateTime: $releaseDateTime, season: $season, episodeType: $episodeType, number: $number, duration: $duration, title: $title, description: $description, variants: $variants, platforms: $platforms, langTypes: $langTypes)';
+  return 'EpisodeMappingDto(uuid: $uuid, anime: $anime, releaseDateTime: $releaseDateTime, season: $season, episodeType: $episodeType, number: $number, duration: $duration, title: $title, description: $description, sources: $sources)';
 }
 
 
@@ -49,7 +48,7 @@ abstract mixin class $EpisodeMappingDtoCopyWith<$Res>  {
   factory $EpisodeMappingDtoCopyWith(EpisodeMappingDto value, $Res Function(EpisodeMappingDto) _then) = _$EpisodeMappingDtoCopyWithImpl;
 @useResult
 $Res call({
- String uuid, AnimeDto? anime, String releaseDateTime, int season, String episodeType, int number, int duration, String? title, String? description, List<EpisodeVariantDto>? variants, List<PlatformDto> platforms, List<String>? langTypes
+ String uuid, AnimeDto? anime, String releaseDateTime, int season, String episodeType, int number, int duration, String? title, String? description, List<EpisodeSourceDto> sources
 });
 
 
@@ -66,7 +65,7 @@ class _$EpisodeMappingDtoCopyWithImpl<$Res>
 
 /// Create a copy of EpisodeMappingDto
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? uuid = null,Object? anime = freezed,Object? releaseDateTime = null,Object? season = null,Object? episodeType = null,Object? number = null,Object? duration = null,Object? title = freezed,Object? description = freezed,Object? variants = freezed,Object? platforms = null,Object? langTypes = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? uuid = null,Object? anime = freezed,Object? releaseDateTime = null,Object? season = null,Object? episodeType = null,Object? number = null,Object? duration = null,Object? title = freezed,Object? description = freezed,Object? sources = null,}) {
   return _then(_self.copyWith(
 uuid: null == uuid ? _self.uuid : uuid // ignore: cast_nullable_to_non_nullable
 as String,anime: freezed == anime ? _self.anime : anime // ignore: cast_nullable_to_non_nullable
@@ -77,10 +76,8 @@ as String,number: null == number ? _self.number : number // ignore: cast_nullabl
 as int,duration: null == duration ? _self.duration : duration // ignore: cast_nullable_to_non_nullable
 as int,title: freezed == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
 as String?,description: freezed == description ? _self.description : description // ignore: cast_nullable_to_non_nullable
-as String?,variants: freezed == variants ? _self.variants : variants // ignore: cast_nullable_to_non_nullable
-as List<EpisodeVariantDto>?,platforms: null == platforms ? _self.platforms : platforms // ignore: cast_nullable_to_non_nullable
-as List<PlatformDto>,langTypes: freezed == langTypes ? _self.langTypes : langTypes // ignore: cast_nullable_to_non_nullable
-as List<String>?,
+as String?,sources: null == sources ? _self.sources : sources // ignore: cast_nullable_to_non_nullable
+as List<EpisodeSourceDto>,
   ));
 }
 /// Create a copy of EpisodeMappingDto
@@ -99,11 +96,135 @@ $AnimeDtoCopyWith<$Res>? get anime {
 }
 
 
+/// Adds pattern-matching-related methods to [EpisodeMappingDto].
+extension EpisodeMappingDtoPatterns on EpisodeMappingDto {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _EpisodeMappingDto value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _EpisodeMappingDto() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _EpisodeMappingDto value)  $default,){
+final _that = this;
+switch (_that) {
+case _EpisodeMappingDto():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _EpisodeMappingDto value)?  $default,){
+final _that = this;
+switch (_that) {
+case _EpisodeMappingDto() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String uuid,  AnimeDto? anime,  String releaseDateTime,  int season,  String episodeType,  int number,  int duration,  String? title,  String? description,  List<EpisodeSourceDto> sources)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _EpisodeMappingDto() when $default != null:
+return $default(_that.uuid,_that.anime,_that.releaseDateTime,_that.season,_that.episodeType,_that.number,_that.duration,_that.title,_that.description,_that.sources);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String uuid,  AnimeDto? anime,  String releaseDateTime,  int season,  String episodeType,  int number,  int duration,  String? title,  String? description,  List<EpisodeSourceDto> sources)  $default,) {final _that = this;
+switch (_that) {
+case _EpisodeMappingDto():
+return $default(_that.uuid,_that.anime,_that.releaseDateTime,_that.season,_that.episodeType,_that.number,_that.duration,_that.title,_that.description,_that.sources);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String uuid,  AnimeDto? anime,  String releaseDateTime,  int season,  String episodeType,  int number,  int duration,  String? title,  String? description,  List<EpisodeSourceDto> sources)?  $default,) {final _that = this;
+switch (_that) {
+case _EpisodeMappingDto() when $default != null:
+return $default(_that.uuid,_that.anime,_that.releaseDateTime,_that.season,_that.episodeType,_that.number,_that.duration,_that.title,_that.description,_that.sources);case _:
+  return null;
+
+}
+}
+
+}
+
 /// @nodoc
 @JsonSerializable()
 
 class _EpisodeMappingDto implements EpisodeMappingDto {
-  const _EpisodeMappingDto({required this.uuid, required this.anime, required this.releaseDateTime, required this.season, required this.episodeType, required this.number, required this.duration, required this.title, required this.description, required final  List<EpisodeVariantDto>? variants, required final  List<PlatformDto> platforms, required final  List<String>? langTypes}): _variants = variants,_platforms = platforms,_langTypes = langTypes;
+  const _EpisodeMappingDto({required this.uuid, required this.anime, required this.releaseDateTime, required this.season, required this.episodeType, required this.number, required this.duration, required this.title, required this.description, required final  List<EpisodeSourceDto> sources}): _sources = sources;
   factory _EpisodeMappingDto.fromJson(Map<String, dynamic> json) => _$EpisodeMappingDtoFromJson(json);
 
 @override final  String uuid;
@@ -115,29 +236,11 @@ class _EpisodeMappingDto implements EpisodeMappingDto {
 @override final  int duration;
 @override final  String? title;
 @override final  String? description;
- final  List<EpisodeVariantDto>? _variants;
-@override List<EpisodeVariantDto>? get variants {
-  final value = _variants;
-  if (value == null) return null;
-  if (_variants is EqualUnmodifiableListView) return _variants;
+ final  List<EpisodeSourceDto> _sources;
+@override List<EpisodeSourceDto> get sources {
+  if (_sources is EqualUnmodifiableListView) return _sources;
   // ignore: implicit_dynamic_type
-  return EqualUnmodifiableListView(value);
-}
-
- final  List<PlatformDto> _platforms;
-@override List<PlatformDto> get platforms {
-  if (_platforms is EqualUnmodifiableListView) return _platforms;
-  // ignore: implicit_dynamic_type
-  return EqualUnmodifiableListView(_platforms);
-}
-
- final  List<String>? _langTypes;
-@override List<String>? get langTypes {
-  final value = _langTypes;
-  if (value == null) return null;
-  if (_langTypes is EqualUnmodifiableListView) return _langTypes;
-  // ignore: implicit_dynamic_type
-  return EqualUnmodifiableListView(value);
+  return EqualUnmodifiableListView(_sources);
 }
 
 
@@ -154,16 +257,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _EpisodeMappingDto&&(identical(other.uuid, uuid) || other.uuid == uuid)&&(identical(other.anime, anime) || other.anime == anime)&&(identical(other.releaseDateTime, releaseDateTime) || other.releaseDateTime == releaseDateTime)&&(identical(other.season, season) || other.season == season)&&(identical(other.episodeType, episodeType) || other.episodeType == episodeType)&&(identical(other.number, number) || other.number == number)&&(identical(other.duration, duration) || other.duration == duration)&&(identical(other.title, title) || other.title == title)&&(identical(other.description, description) || other.description == description)&&const DeepCollectionEquality().equals(other._variants, _variants)&&const DeepCollectionEquality().equals(other._platforms, _platforms)&&const DeepCollectionEquality().equals(other._langTypes, _langTypes));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _EpisodeMappingDto&&(identical(other.uuid, uuid) || other.uuid == uuid)&&(identical(other.anime, anime) || other.anime == anime)&&(identical(other.releaseDateTime, releaseDateTime) || other.releaseDateTime == releaseDateTime)&&(identical(other.season, season) || other.season == season)&&(identical(other.episodeType, episodeType) || other.episodeType == episodeType)&&(identical(other.number, number) || other.number == number)&&(identical(other.duration, duration) || other.duration == duration)&&(identical(other.title, title) || other.title == title)&&(identical(other.description, description) || other.description == description)&&const DeepCollectionEquality().equals(other._sources, _sources));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,uuid,anime,releaseDateTime,season,episodeType,number,duration,title,description,const DeepCollectionEquality().hash(_variants),const DeepCollectionEquality().hash(_platforms),const DeepCollectionEquality().hash(_langTypes));
+int get hashCode => Object.hash(runtimeType,uuid,anime,releaseDateTime,season,episodeType,number,duration,title,description,const DeepCollectionEquality().hash(_sources));
 
 @override
 String toString() {
-  return 'EpisodeMappingDto(uuid: $uuid, anime: $anime, releaseDateTime: $releaseDateTime, season: $season, episodeType: $episodeType, number: $number, duration: $duration, title: $title, description: $description, variants: $variants, platforms: $platforms, langTypes: $langTypes)';
+  return 'EpisodeMappingDto(uuid: $uuid, anime: $anime, releaseDateTime: $releaseDateTime, season: $season, episodeType: $episodeType, number: $number, duration: $duration, title: $title, description: $description, sources: $sources)';
 }
 
 
@@ -174,7 +277,7 @@ abstract mixin class _$EpisodeMappingDtoCopyWith<$Res> implements $EpisodeMappin
   factory _$EpisodeMappingDtoCopyWith(_EpisodeMappingDto value, $Res Function(_EpisodeMappingDto) _then) = __$EpisodeMappingDtoCopyWithImpl;
 @override @useResult
 $Res call({
- String uuid, AnimeDto? anime, String releaseDateTime, int season, String episodeType, int number, int duration, String? title, String? description, List<EpisodeVariantDto>? variants, List<PlatformDto> platforms, List<String>? langTypes
+ String uuid, AnimeDto? anime, String releaseDateTime, int season, String episodeType, int number, int duration, String? title, String? description, List<EpisodeSourceDto> sources
 });
 
 
@@ -191,7 +294,7 @@ class __$EpisodeMappingDtoCopyWithImpl<$Res>
 
 /// Create a copy of EpisodeMappingDto
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? uuid = null,Object? anime = freezed,Object? releaseDateTime = null,Object? season = null,Object? episodeType = null,Object? number = null,Object? duration = null,Object? title = freezed,Object? description = freezed,Object? variants = freezed,Object? platforms = null,Object? langTypes = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? uuid = null,Object? anime = freezed,Object? releaseDateTime = null,Object? season = null,Object? episodeType = null,Object? number = null,Object? duration = null,Object? title = freezed,Object? description = freezed,Object? sources = null,}) {
   return _then(_EpisodeMappingDto(
 uuid: null == uuid ? _self.uuid : uuid // ignore: cast_nullable_to_non_nullable
 as String,anime: freezed == anime ? _self.anime : anime // ignore: cast_nullable_to_non_nullable
@@ -202,10 +305,8 @@ as String,number: null == number ? _self.number : number // ignore: cast_nullabl
 as int,duration: null == duration ? _self.duration : duration // ignore: cast_nullable_to_non_nullable
 as int,title: freezed == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
 as String?,description: freezed == description ? _self.description : description // ignore: cast_nullable_to_non_nullable
-as String?,variants: freezed == variants ? _self._variants : variants // ignore: cast_nullable_to_non_nullable
-as List<EpisodeVariantDto>?,platforms: null == platforms ? _self._platforms : platforms // ignore: cast_nullable_to_non_nullable
-as List<PlatformDto>,langTypes: freezed == langTypes ? _self._langTypes : langTypes // ignore: cast_nullable_to_non_nullable
-as List<String>?,
+as String?,sources: null == sources ? _self._sources : sources // ignore: cast_nullable_to_non_nullable
+as List<EpisodeSourceDto>,
   ));
 }
 

--- a/lib/dtos/episode_mapping_dto.g.dart
+++ b/lib/dtos/episode_mapping_dto.g.dart
@@ -19,14 +19,8 @@ _EpisodeMappingDto _$EpisodeMappingDtoFromJson(Map<String, dynamic> json) =>
       duration: (json['duration'] as num).toInt(),
       title: json['title'] as String?,
       description: json['description'] as String?,
-      variants: (json['variants'] as List<dynamic>?)
-          ?.map((e) => EpisodeVariantDto.fromJson(e as Map<String, dynamic>))
-          .toList(),
-      platforms: (json['platforms'] as List<dynamic>)
-          .map((e) => PlatformDto.fromJson(e as Map<String, dynamic>))
-          .toList(),
-      langTypes: (json['langTypes'] as List<dynamic>?)
-          ?.map((e) => e as String)
+      sources: (json['sources'] as List<dynamic>)
+          .map((e) => EpisodeSourceDto.fromJson(e as Map<String, dynamic>))
           .toList(),
     );
 
@@ -41,7 +35,5 @@ Map<String, dynamic> _$EpisodeMappingDtoToJson(_EpisodeMappingDto instance) =>
       'duration': instance.duration,
       'title': instance.title,
       'description': instance.description,
-      'variants': instance.variants,
-      'platforms': instance.platforms,
-      'langTypes': instance.langTypes,
+      'sources': instance.sources,
     };

--- a/lib/dtos/episode_source_dto.dart
+++ b/lib/dtos/episode_source_dto.dart
@@ -1,0 +1,17 @@
+import 'package:application/dtos/platform_dto.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'episode_source_dto.freezed.dart';
+part 'episode_source_dto.g.dart';
+
+@freezed
+sealed class EpisodeSourceDto with _$EpisodeSourceDto {
+  const factory EpisodeSourceDto({
+    required final PlatformDto platform,
+    required final String url,
+    required final String langType,
+  }) = _EpisodeSourceDto;
+
+  factory EpisodeSourceDto.fromJson(final Map<String, dynamic> json) =>
+      _$EpisodeSourceDtoFromJson(json);
+}

--- a/lib/dtos/episode_source_dto.freezed.dart
+++ b/lib/dtos/episode_source_dto.freezed.dart
@@ -1,0 +1,295 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'episode_source_dto.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$EpisodeSourceDto {
+
+ PlatformDto get platform; String get url; String get langType;
+/// Create a copy of EpisodeSourceDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$EpisodeSourceDtoCopyWith<EpisodeSourceDto> get copyWith => _$EpisodeSourceDtoCopyWithImpl<EpisodeSourceDto>(this as EpisodeSourceDto, _$identity);
+
+  /// Serializes this EpisodeSourceDto to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is EpisodeSourceDto&&(identical(other.platform, platform) || other.platform == platform)&&(identical(other.url, url) || other.url == url)&&(identical(other.langType, langType) || other.langType == langType));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,platform,url,langType);
+
+@override
+String toString() {
+  return 'EpisodeSourceDto(platform: $platform, url: $url, langType: $langType)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $EpisodeSourceDtoCopyWith<$Res>  {
+  factory $EpisodeSourceDtoCopyWith(EpisodeSourceDto value, $Res Function(EpisodeSourceDto) _then) = _$EpisodeSourceDtoCopyWithImpl;
+@useResult
+$Res call({
+ PlatformDto platform, String url, String langType
+});
+
+
+$PlatformDtoCopyWith<$Res> get platform;
+
+}
+/// @nodoc
+class _$EpisodeSourceDtoCopyWithImpl<$Res>
+    implements $EpisodeSourceDtoCopyWith<$Res> {
+  _$EpisodeSourceDtoCopyWithImpl(this._self, this._then);
+
+  final EpisodeSourceDto _self;
+  final $Res Function(EpisodeSourceDto) _then;
+
+/// Create a copy of EpisodeSourceDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? platform = null,Object? url = null,Object? langType = null,}) {
+  return _then(_self.copyWith(
+platform: null == platform ? _self.platform : platform // ignore: cast_nullable_to_non_nullable
+as PlatformDto,url: null == url ? _self.url : url // ignore: cast_nullable_to_non_nullable
+as String,langType: null == langType ? _self.langType : langType // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+/// Create a copy of EpisodeSourceDto
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$PlatformDtoCopyWith<$Res> get platform {
+  
+  return $PlatformDtoCopyWith<$Res>(_self.platform, (value) {
+    return _then(_self.copyWith(platform: value));
+  });
+}
+}
+
+
+/// Adds pattern-matching-related methods to [EpisodeSourceDto].
+extension EpisodeSourceDtoPatterns on EpisodeSourceDto {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _EpisodeSourceDto value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _EpisodeSourceDto() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _EpisodeSourceDto value)  $default,){
+final _that = this;
+switch (_that) {
+case _EpisodeSourceDto():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _EpisodeSourceDto value)?  $default,){
+final _that = this;
+switch (_that) {
+case _EpisodeSourceDto() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( PlatformDto platform,  String url,  String langType)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _EpisodeSourceDto() when $default != null:
+return $default(_that.platform,_that.url,_that.langType);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( PlatformDto platform,  String url,  String langType)  $default,) {final _that = this;
+switch (_that) {
+case _EpisodeSourceDto():
+return $default(_that.platform,_that.url,_that.langType);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( PlatformDto platform,  String url,  String langType)?  $default,) {final _that = this;
+switch (_that) {
+case _EpisodeSourceDto() when $default != null:
+return $default(_that.platform,_that.url,_that.langType);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _EpisodeSourceDto implements EpisodeSourceDto {
+  const _EpisodeSourceDto({required this.platform, required this.url, required this.langType});
+  factory _EpisodeSourceDto.fromJson(Map<String, dynamic> json) => _$EpisodeSourceDtoFromJson(json);
+
+@override final  PlatformDto platform;
+@override final  String url;
+@override final  String langType;
+
+/// Create a copy of EpisodeSourceDto
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$EpisodeSourceDtoCopyWith<_EpisodeSourceDto> get copyWith => __$EpisodeSourceDtoCopyWithImpl<_EpisodeSourceDto>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$EpisodeSourceDtoToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _EpisodeSourceDto&&(identical(other.platform, platform) || other.platform == platform)&&(identical(other.url, url) || other.url == url)&&(identical(other.langType, langType) || other.langType == langType));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,platform,url,langType);
+
+@override
+String toString() {
+  return 'EpisodeSourceDto(platform: $platform, url: $url, langType: $langType)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$EpisodeSourceDtoCopyWith<$Res> implements $EpisodeSourceDtoCopyWith<$Res> {
+  factory _$EpisodeSourceDtoCopyWith(_EpisodeSourceDto value, $Res Function(_EpisodeSourceDto) _then) = __$EpisodeSourceDtoCopyWithImpl;
+@override @useResult
+$Res call({
+ PlatformDto platform, String url, String langType
+});
+
+
+@override $PlatformDtoCopyWith<$Res> get platform;
+
+}
+/// @nodoc
+class __$EpisodeSourceDtoCopyWithImpl<$Res>
+    implements _$EpisodeSourceDtoCopyWith<$Res> {
+  __$EpisodeSourceDtoCopyWithImpl(this._self, this._then);
+
+  final _EpisodeSourceDto _self;
+  final $Res Function(_EpisodeSourceDto) _then;
+
+/// Create a copy of EpisodeSourceDto
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? platform = null,Object? url = null,Object? langType = null,}) {
+  return _then(_EpisodeSourceDto(
+platform: null == platform ? _self.platform : platform // ignore: cast_nullable_to_non_nullable
+as PlatformDto,url: null == url ? _self.url : url // ignore: cast_nullable_to_non_nullable
+as String,langType: null == langType ? _self.langType : langType // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+/// Create a copy of EpisodeSourceDto
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$PlatformDtoCopyWith<$Res> get platform {
+  
+  return $PlatformDtoCopyWith<$Res>(_self.platform, (value) {
+    return _then(_self.copyWith(platform: value));
+  });
+}
+}
+
+// dart format on

--- a/lib/dtos/episode_source_dto.g.dart
+++ b/lib/dtos/episode_source_dto.g.dart
@@ -1,0 +1,21 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'episode_source_dto.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_EpisodeSourceDto _$EpisodeSourceDtoFromJson(Map<String, dynamic> json) =>
+    _EpisodeSourceDto(
+      platform: PlatformDto.fromJson(json['platform'] as Map<String, dynamic>),
+      url: json['url'] as String,
+      langType: json['langType'] as String,
+    );
+
+Map<String, dynamic> _$EpisodeSourceDtoToJson(_EpisodeSourceDto instance) =>
+    <String, dynamic>{
+      'platform': instance.platform,
+      'url': instance.url,
+      'langType': instance.langType,
+    };

--- a/lib/dtos/episode_variant_dto.freezed.dart
+++ b/lib/dtos/episode_variant_dto.freezed.dart
@@ -1,6 +1,5 @@
-// dart format width=80
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -76,6 +75,130 @@ as String,
 
 }
 
+
+/// Adds pattern-matching-related methods to [EpisodeVariantDto].
+extension EpisodeVariantDtoPatterns on EpisodeVariantDto {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _EpisodeVariantDto value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _EpisodeVariantDto() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _EpisodeVariantDto value)  $default,){
+final _that = this;
+switch (_that) {
+case _EpisodeVariantDto():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _EpisodeVariantDto value)?  $default,){
+final _that = this;
+switch (_that) {
+case _EpisodeVariantDto() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String uuid,  String url)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _EpisodeVariantDto() when $default != null:
+return $default(_that.uuid,_that.url);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String uuid,  String url)  $default,) {final _that = this;
+switch (_that) {
+case _EpisodeVariantDto():
+return $default(_that.uuid,_that.url);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String uuid,  String url)?  $default,) {final _that = this;
+switch (_that) {
+case _EpisodeVariantDto() when $default != null:
+return $default(_that.uuid,_that.url);case _:
+  return null;
+
+}
+}
+
+}
 
 /// @nodoc
 @JsonSerializable()

--- a/lib/dtos/grouped_episode_dto.dart
+++ b/lib/dtos/grouped_episode_dto.dart
@@ -1,5 +1,5 @@
 import 'package:application/dtos/anime_dto.dart';
-import 'package:application/dtos/platform_dto.dart';
+import 'package:application/dtos/episode_source_dto.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'grouped_episode_dto.freezed.dart';
@@ -9,17 +9,15 @@ part 'grouped_episode_dto.g.dart';
 sealed class GroupedEpisodeDto with _$GroupedEpisodeDto {
   const factory GroupedEpisodeDto({
     required final AnimeDto anime,
-    required final List<PlatformDto> platforms,
     required final String releaseDateTime,
     required final String season,
     required final String episodeType,
     required final String number,
-    required final List<String> langTypes,
     required final String? title,
     required final String? description,
     required final int? duration,
     required final List<String> mappings,
-    required final List<String> urls,
+    required final List<EpisodeSourceDto> sources,
   }) = _GroupedEpisodeDto;
 
   factory GroupedEpisodeDto.fromJson(final Map<String, dynamic> json) =>

--- a/lib/dtos/grouped_episode_dto.freezed.dart
+++ b/lib/dtos/grouped_episode_dto.freezed.dart
@@ -1,6 +1,5 @@
-// dart format width=80
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -16,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$GroupedEpisodeDto {
 
- AnimeDto get anime; List<PlatformDto> get platforms; String get releaseDateTime; String get season; String get episodeType; String get number; List<String> get langTypes; String? get title; String? get description; int? get duration; List<String> get mappings; List<String> get urls;
+ AnimeDto get anime; String get releaseDateTime; String get season; String get episodeType; String get number; String? get title; String? get description; int? get duration; List<String> get mappings; List<EpisodeSourceDto> get sources;
 /// Create a copy of GroupedEpisodeDto
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -29,16 +28,16 @@ $GroupedEpisodeDtoCopyWith<GroupedEpisodeDto> get copyWith => _$GroupedEpisodeDt
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is GroupedEpisodeDto&&(identical(other.anime, anime) || other.anime == anime)&&const DeepCollectionEquality().equals(other.platforms, platforms)&&(identical(other.releaseDateTime, releaseDateTime) || other.releaseDateTime == releaseDateTime)&&(identical(other.season, season) || other.season == season)&&(identical(other.episodeType, episodeType) || other.episodeType == episodeType)&&(identical(other.number, number) || other.number == number)&&const DeepCollectionEquality().equals(other.langTypes, langTypes)&&(identical(other.title, title) || other.title == title)&&(identical(other.description, description) || other.description == description)&&(identical(other.duration, duration) || other.duration == duration)&&const DeepCollectionEquality().equals(other.mappings, mappings)&&const DeepCollectionEquality().equals(other.urls, urls));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is GroupedEpisodeDto&&(identical(other.anime, anime) || other.anime == anime)&&(identical(other.releaseDateTime, releaseDateTime) || other.releaseDateTime == releaseDateTime)&&(identical(other.season, season) || other.season == season)&&(identical(other.episodeType, episodeType) || other.episodeType == episodeType)&&(identical(other.number, number) || other.number == number)&&(identical(other.title, title) || other.title == title)&&(identical(other.description, description) || other.description == description)&&(identical(other.duration, duration) || other.duration == duration)&&const DeepCollectionEquality().equals(other.mappings, mappings)&&const DeepCollectionEquality().equals(other.sources, sources));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,anime,const DeepCollectionEquality().hash(platforms),releaseDateTime,season,episodeType,number,const DeepCollectionEquality().hash(langTypes),title,description,duration,const DeepCollectionEquality().hash(mappings),const DeepCollectionEquality().hash(urls));
+int get hashCode => Object.hash(runtimeType,anime,releaseDateTime,season,episodeType,number,title,description,duration,const DeepCollectionEquality().hash(mappings),const DeepCollectionEquality().hash(sources));
 
 @override
 String toString() {
-  return 'GroupedEpisodeDto(anime: $anime, platforms: $platforms, releaseDateTime: $releaseDateTime, season: $season, episodeType: $episodeType, number: $number, langTypes: $langTypes, title: $title, description: $description, duration: $duration, mappings: $mappings, urls: $urls)';
+  return 'GroupedEpisodeDto(anime: $anime, releaseDateTime: $releaseDateTime, season: $season, episodeType: $episodeType, number: $number, title: $title, description: $description, duration: $duration, mappings: $mappings, sources: $sources)';
 }
 
 
@@ -49,7 +48,7 @@ abstract mixin class $GroupedEpisodeDtoCopyWith<$Res>  {
   factory $GroupedEpisodeDtoCopyWith(GroupedEpisodeDto value, $Res Function(GroupedEpisodeDto) _then) = _$GroupedEpisodeDtoCopyWithImpl;
 @useResult
 $Res call({
- AnimeDto anime, List<PlatformDto> platforms, String releaseDateTime, String season, String episodeType, String number, List<String> langTypes, String? title, String? description, int? duration, List<String> mappings, List<String> urls
+ AnimeDto anime, String releaseDateTime, String season, String episodeType, String number, String? title, String? description, int? duration, List<String> mappings, List<EpisodeSourceDto> sources
 });
 
 
@@ -66,21 +65,19 @@ class _$GroupedEpisodeDtoCopyWithImpl<$Res>
 
 /// Create a copy of GroupedEpisodeDto
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? anime = null,Object? platforms = null,Object? releaseDateTime = null,Object? season = null,Object? episodeType = null,Object? number = null,Object? langTypes = null,Object? title = freezed,Object? description = freezed,Object? duration = freezed,Object? mappings = null,Object? urls = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? anime = null,Object? releaseDateTime = null,Object? season = null,Object? episodeType = null,Object? number = null,Object? title = freezed,Object? description = freezed,Object? duration = freezed,Object? mappings = null,Object? sources = null,}) {
   return _then(_self.copyWith(
 anime: null == anime ? _self.anime : anime // ignore: cast_nullable_to_non_nullable
-as AnimeDto,platforms: null == platforms ? _self.platforms : platforms // ignore: cast_nullable_to_non_nullable
-as List<PlatformDto>,releaseDateTime: null == releaseDateTime ? _self.releaseDateTime : releaseDateTime // ignore: cast_nullable_to_non_nullable
+as AnimeDto,releaseDateTime: null == releaseDateTime ? _self.releaseDateTime : releaseDateTime // ignore: cast_nullable_to_non_nullable
 as String,season: null == season ? _self.season : season // ignore: cast_nullable_to_non_nullable
 as String,episodeType: null == episodeType ? _self.episodeType : episodeType // ignore: cast_nullable_to_non_nullable
 as String,number: null == number ? _self.number : number // ignore: cast_nullable_to_non_nullable
-as String,langTypes: null == langTypes ? _self.langTypes : langTypes // ignore: cast_nullable_to_non_nullable
-as List<String>,title: freezed == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
+as String,title: freezed == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
 as String?,description: freezed == description ? _self.description : description // ignore: cast_nullable_to_non_nullable
 as String?,duration: freezed == duration ? _self.duration : duration // ignore: cast_nullable_to_non_nullable
 as int?,mappings: null == mappings ? _self.mappings : mappings // ignore: cast_nullable_to_non_nullable
-as List<String>,urls: null == urls ? _self.urls : urls // ignore: cast_nullable_to_non_nullable
-as List<String>,
+as List<String>,sources: null == sources ? _self.sources : sources // ignore: cast_nullable_to_non_nullable
+as List<EpisodeSourceDto>,
   ));
 }
 /// Create a copy of GroupedEpisodeDto
@@ -96,32 +93,142 @@ $AnimeDtoCopyWith<$Res> get anime {
 }
 
 
+/// Adds pattern-matching-related methods to [GroupedEpisodeDto].
+extension GroupedEpisodeDtoPatterns on GroupedEpisodeDto {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _GroupedEpisodeDto value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _GroupedEpisodeDto() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _GroupedEpisodeDto value)  $default,){
+final _that = this;
+switch (_that) {
+case _GroupedEpisodeDto():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _GroupedEpisodeDto value)?  $default,){
+final _that = this;
+switch (_that) {
+case _GroupedEpisodeDto() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( AnimeDto anime,  String releaseDateTime,  String season,  String episodeType,  String number,  String? title,  String? description,  int? duration,  List<String> mappings,  List<EpisodeSourceDto> sources)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _GroupedEpisodeDto() when $default != null:
+return $default(_that.anime,_that.releaseDateTime,_that.season,_that.episodeType,_that.number,_that.title,_that.description,_that.duration,_that.mappings,_that.sources);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( AnimeDto anime,  String releaseDateTime,  String season,  String episodeType,  String number,  String? title,  String? description,  int? duration,  List<String> mappings,  List<EpisodeSourceDto> sources)  $default,) {final _that = this;
+switch (_that) {
+case _GroupedEpisodeDto():
+return $default(_that.anime,_that.releaseDateTime,_that.season,_that.episodeType,_that.number,_that.title,_that.description,_that.duration,_that.mappings,_that.sources);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( AnimeDto anime,  String releaseDateTime,  String season,  String episodeType,  String number,  String? title,  String? description,  int? duration,  List<String> mappings,  List<EpisodeSourceDto> sources)?  $default,) {final _that = this;
+switch (_that) {
+case _GroupedEpisodeDto() when $default != null:
+return $default(_that.anime,_that.releaseDateTime,_that.season,_that.episodeType,_that.number,_that.title,_that.description,_that.duration,_that.mappings,_that.sources);case _:
+  return null;
+
+}
+}
+
+}
+
 /// @nodoc
 @JsonSerializable()
 
 class _GroupedEpisodeDto implements GroupedEpisodeDto {
-  const _GroupedEpisodeDto({required this.anime, required final  List<PlatformDto> platforms, required this.releaseDateTime, required this.season, required this.episodeType, required this.number, required final  List<String> langTypes, required this.title, required this.description, required this.duration, required final  List<String> mappings, required final  List<String> urls}): _platforms = platforms,_langTypes = langTypes,_mappings = mappings,_urls = urls;
+  const _GroupedEpisodeDto({required this.anime, required this.releaseDateTime, required this.season, required this.episodeType, required this.number, required this.title, required this.description, required this.duration, required final  List<String> mappings, required final  List<EpisodeSourceDto> sources}): _mappings = mappings,_sources = sources;
   factory _GroupedEpisodeDto.fromJson(Map<String, dynamic> json) => _$GroupedEpisodeDtoFromJson(json);
 
 @override final  AnimeDto anime;
- final  List<PlatformDto> _platforms;
-@override List<PlatformDto> get platforms {
-  if (_platforms is EqualUnmodifiableListView) return _platforms;
-  // ignore: implicit_dynamic_type
-  return EqualUnmodifiableListView(_platforms);
-}
-
 @override final  String releaseDateTime;
 @override final  String season;
 @override final  String episodeType;
 @override final  String number;
- final  List<String> _langTypes;
-@override List<String> get langTypes {
-  if (_langTypes is EqualUnmodifiableListView) return _langTypes;
-  // ignore: implicit_dynamic_type
-  return EqualUnmodifiableListView(_langTypes);
-}
-
 @override final  String? title;
 @override final  String? description;
 @override final  int? duration;
@@ -132,11 +239,11 @@ class _GroupedEpisodeDto implements GroupedEpisodeDto {
   return EqualUnmodifiableListView(_mappings);
 }
 
- final  List<String> _urls;
-@override List<String> get urls {
-  if (_urls is EqualUnmodifiableListView) return _urls;
+ final  List<EpisodeSourceDto> _sources;
+@override List<EpisodeSourceDto> get sources {
+  if (_sources is EqualUnmodifiableListView) return _sources;
   // ignore: implicit_dynamic_type
-  return EqualUnmodifiableListView(_urls);
+  return EqualUnmodifiableListView(_sources);
 }
 
 
@@ -153,16 +260,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _GroupedEpisodeDto&&(identical(other.anime, anime) || other.anime == anime)&&const DeepCollectionEquality().equals(other._platforms, _platforms)&&(identical(other.releaseDateTime, releaseDateTime) || other.releaseDateTime == releaseDateTime)&&(identical(other.season, season) || other.season == season)&&(identical(other.episodeType, episodeType) || other.episodeType == episodeType)&&(identical(other.number, number) || other.number == number)&&const DeepCollectionEquality().equals(other._langTypes, _langTypes)&&(identical(other.title, title) || other.title == title)&&(identical(other.description, description) || other.description == description)&&(identical(other.duration, duration) || other.duration == duration)&&const DeepCollectionEquality().equals(other._mappings, _mappings)&&const DeepCollectionEquality().equals(other._urls, _urls));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _GroupedEpisodeDto&&(identical(other.anime, anime) || other.anime == anime)&&(identical(other.releaseDateTime, releaseDateTime) || other.releaseDateTime == releaseDateTime)&&(identical(other.season, season) || other.season == season)&&(identical(other.episodeType, episodeType) || other.episodeType == episodeType)&&(identical(other.number, number) || other.number == number)&&(identical(other.title, title) || other.title == title)&&(identical(other.description, description) || other.description == description)&&(identical(other.duration, duration) || other.duration == duration)&&const DeepCollectionEquality().equals(other._mappings, _mappings)&&const DeepCollectionEquality().equals(other._sources, _sources));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,anime,const DeepCollectionEquality().hash(_platforms),releaseDateTime,season,episodeType,number,const DeepCollectionEquality().hash(_langTypes),title,description,duration,const DeepCollectionEquality().hash(_mappings),const DeepCollectionEquality().hash(_urls));
+int get hashCode => Object.hash(runtimeType,anime,releaseDateTime,season,episodeType,number,title,description,duration,const DeepCollectionEquality().hash(_mappings),const DeepCollectionEquality().hash(_sources));
 
 @override
 String toString() {
-  return 'GroupedEpisodeDto(anime: $anime, platforms: $platforms, releaseDateTime: $releaseDateTime, season: $season, episodeType: $episodeType, number: $number, langTypes: $langTypes, title: $title, description: $description, duration: $duration, mappings: $mappings, urls: $urls)';
+  return 'GroupedEpisodeDto(anime: $anime, releaseDateTime: $releaseDateTime, season: $season, episodeType: $episodeType, number: $number, title: $title, description: $description, duration: $duration, mappings: $mappings, sources: $sources)';
 }
 
 
@@ -173,7 +280,7 @@ abstract mixin class _$GroupedEpisodeDtoCopyWith<$Res> implements $GroupedEpisod
   factory _$GroupedEpisodeDtoCopyWith(_GroupedEpisodeDto value, $Res Function(_GroupedEpisodeDto) _then) = __$GroupedEpisodeDtoCopyWithImpl;
 @override @useResult
 $Res call({
- AnimeDto anime, List<PlatformDto> platforms, String releaseDateTime, String season, String episodeType, String number, List<String> langTypes, String? title, String? description, int? duration, List<String> mappings, List<String> urls
+ AnimeDto anime, String releaseDateTime, String season, String episodeType, String number, String? title, String? description, int? duration, List<String> mappings, List<EpisodeSourceDto> sources
 });
 
 
@@ -190,21 +297,19 @@ class __$GroupedEpisodeDtoCopyWithImpl<$Res>
 
 /// Create a copy of GroupedEpisodeDto
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? anime = null,Object? platforms = null,Object? releaseDateTime = null,Object? season = null,Object? episodeType = null,Object? number = null,Object? langTypes = null,Object? title = freezed,Object? description = freezed,Object? duration = freezed,Object? mappings = null,Object? urls = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? anime = null,Object? releaseDateTime = null,Object? season = null,Object? episodeType = null,Object? number = null,Object? title = freezed,Object? description = freezed,Object? duration = freezed,Object? mappings = null,Object? sources = null,}) {
   return _then(_GroupedEpisodeDto(
 anime: null == anime ? _self.anime : anime // ignore: cast_nullable_to_non_nullable
-as AnimeDto,platforms: null == platforms ? _self._platforms : platforms // ignore: cast_nullable_to_non_nullable
-as List<PlatformDto>,releaseDateTime: null == releaseDateTime ? _self.releaseDateTime : releaseDateTime // ignore: cast_nullable_to_non_nullable
+as AnimeDto,releaseDateTime: null == releaseDateTime ? _self.releaseDateTime : releaseDateTime // ignore: cast_nullable_to_non_nullable
 as String,season: null == season ? _self.season : season // ignore: cast_nullable_to_non_nullable
 as String,episodeType: null == episodeType ? _self.episodeType : episodeType // ignore: cast_nullable_to_non_nullable
 as String,number: null == number ? _self.number : number // ignore: cast_nullable_to_non_nullable
-as String,langTypes: null == langTypes ? _self._langTypes : langTypes // ignore: cast_nullable_to_non_nullable
-as List<String>,title: freezed == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
+as String,title: freezed == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
 as String?,description: freezed == description ? _self.description : description // ignore: cast_nullable_to_non_nullable
 as String?,duration: freezed == duration ? _self.duration : duration // ignore: cast_nullable_to_non_nullable
 as int?,mappings: null == mappings ? _self._mappings : mappings // ignore: cast_nullable_to_non_nullable
-as List<String>,urls: null == urls ? _self._urls : urls // ignore: cast_nullable_to_non_nullable
-as List<String>,
+as List<String>,sources: null == sources ? _self._sources : sources // ignore: cast_nullable_to_non_nullable
+as List<EpisodeSourceDto>,
   ));
 }
 

--- a/lib/dtos/grouped_episode_dto.g.dart
+++ b/lib/dtos/grouped_episode_dto.g.dart
@@ -9,37 +9,31 @@ part of 'grouped_episode_dto.dart';
 _GroupedEpisodeDto _$GroupedEpisodeDtoFromJson(Map<String, dynamic> json) =>
     _GroupedEpisodeDto(
       anime: AnimeDto.fromJson(json['anime'] as Map<String, dynamic>),
-      platforms: (json['platforms'] as List<dynamic>)
-          .map((e) => PlatformDto.fromJson(e as Map<String, dynamic>))
-          .toList(),
       releaseDateTime: json['releaseDateTime'] as String,
       season: json['season'] as String,
       episodeType: json['episodeType'] as String,
       number: json['number'] as String,
-      langTypes: (json['langTypes'] as List<dynamic>)
-          .map((e) => e as String)
-          .toList(),
       title: json['title'] as String?,
       description: json['description'] as String?,
       duration: (json['duration'] as num?)?.toInt(),
       mappings: (json['mappings'] as List<dynamic>)
           .map((e) => e as String)
           .toList(),
-      urls: (json['urls'] as List<dynamic>).map((e) => e as String).toList(),
+      sources: (json['sources'] as List<dynamic>)
+          .map((e) => EpisodeSourceDto.fromJson(e as Map<String, dynamic>))
+          .toList(),
     );
 
 Map<String, dynamic> _$GroupedEpisodeDtoToJson(_GroupedEpisodeDto instance) =>
     <String, dynamic>{
       'anime': instance.anime,
-      'platforms': instance.platforms,
       'releaseDateTime': instance.releaseDateTime,
       'season': instance.season,
       'episodeType': instance.episodeType,
       'number': instance.number,
-      'langTypes': instance.langTypes,
       'title': instance.title,
       'description': instance.description,
       'duration': instance.duration,
       'mappings': instance.mappings,
-      'urls': instance.urls,
+      'sources': instance.sources,
     };

--- a/lib/dtos/member_dto.freezed.dart
+++ b/lib/dtos/member_dto.freezed.dart
@@ -1,6 +1,5 @@
-// dart format width=80
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -83,6 +82,130 @@ as String?,
 
 }
 
+
+/// Adds pattern-matching-related methods to [MemberDto].
+extension MemberDtoPatterns on MemberDto {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _MemberDto value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _MemberDto() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _MemberDto value)  $default,){
+final _that = this;
+switch (_that) {
+case _MemberDto():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _MemberDto value)?  $default,){
+final _that = this;
+switch (_that) {
+case _MemberDto() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String uuid,  String token,  String creationDateTime,  String? email,  List<String> followedAnimes,  List<String> followedEpisodes,  int totalDuration,  int totalUnseenDuration,  String? attachmentLastUpdateDateTime)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _MemberDto() when $default != null:
+return $default(_that.uuid,_that.token,_that.creationDateTime,_that.email,_that.followedAnimes,_that.followedEpisodes,_that.totalDuration,_that.totalUnseenDuration,_that.attachmentLastUpdateDateTime);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String uuid,  String token,  String creationDateTime,  String? email,  List<String> followedAnimes,  List<String> followedEpisodes,  int totalDuration,  int totalUnseenDuration,  String? attachmentLastUpdateDateTime)  $default,) {final _that = this;
+switch (_that) {
+case _MemberDto():
+return $default(_that.uuid,_that.token,_that.creationDateTime,_that.email,_that.followedAnimes,_that.followedEpisodes,_that.totalDuration,_that.totalUnseenDuration,_that.attachmentLastUpdateDateTime);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String uuid,  String token,  String creationDateTime,  String? email,  List<String> followedAnimes,  List<String> followedEpisodes,  int totalDuration,  int totalUnseenDuration,  String? attachmentLastUpdateDateTime)?  $default,) {final _that = this;
+switch (_that) {
+case _MemberDto() when $default != null:
+return $default(_that.uuid,_that.token,_that.creationDateTime,_that.email,_that.followedAnimes,_that.followedEpisodes,_that.totalDuration,_that.totalUnseenDuration,_that.attachmentLastUpdateDateTime);case _:
+  return null;
+
+}
+}
+
+}
 
 /// @nodoc
 @JsonSerializable()

--- a/lib/dtos/missed_anime_dto.freezed.dart
+++ b/lib/dtos/missed_anime_dto.freezed.dart
@@ -1,6 +1,5 @@
-// dart format width=80
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -85,6 +84,130 @@ $AnimeDtoCopyWith<$Res> get anime {
 }
 }
 
+
+/// Adds pattern-matching-related methods to [MissedAnimeDto].
+extension MissedAnimeDtoPatterns on MissedAnimeDto {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _MissedAnimeDto value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _MissedAnimeDto() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _MissedAnimeDto value)  $default,){
+final _that = this;
+switch (_that) {
+case _MissedAnimeDto():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _MissedAnimeDto value)?  $default,){
+final _that = this;
+switch (_that) {
+case _MissedAnimeDto() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( AnimeDto anime,  int episodeMissed)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _MissedAnimeDto() when $default != null:
+return $default(_that.anime,_that.episodeMissed);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( AnimeDto anime,  int episodeMissed)  $default,) {final _that = this;
+switch (_that) {
+case _MissedAnimeDto():
+return $default(_that.anime,_that.episodeMissed);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( AnimeDto anime,  int episodeMissed)?  $default,) {final _that = this;
+switch (_that) {
+case _MissedAnimeDto() when $default != null:
+return $default(_that.anime,_that.episodeMissed);case _:
+  return null;
+
+}
+}
+
+}
 
 /// @nodoc
 @JsonSerializable()

--- a/lib/dtos/pageable_dto.freezed.dart
+++ b/lib/dtos/pageable_dto.freezed.dart
@@ -1,6 +1,5 @@
-// dart format width=80
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -78,6 +77,130 @@ as int,
 
 }
 
+
+/// Adds pattern-matching-related methods to [PageableDto].
+extension PageableDtoPatterns on PageableDto {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _PageableDto value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _PageableDto() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _PageableDto value)  $default,){
+final _that = this;
+switch (_that) {
+case _PageableDto():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _PageableDto value)?  $default,){
+final _that = this;
+switch (_that) {
+case _PageableDto() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( List<dynamic> data,  int page,  int limit,  int total)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _PageableDto() when $default != null:
+return $default(_that.data,_that.page,_that.limit,_that.total);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( List<dynamic> data,  int page,  int limit,  int total)  $default,) {final _that = this;
+switch (_that) {
+case _PageableDto():
+return $default(_that.data,_that.page,_that.limit,_that.total);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( List<dynamic> data,  int page,  int limit,  int total)?  $default,) {final _that = this;
+switch (_that) {
+case _PageableDto() when $default != null:
+return $default(_that.data,_that.page,_that.limit,_that.total);case _:
+  return null;
+
+}
+}
+
+}
 
 /// @nodoc
 @JsonSerializable()

--- a/lib/dtos/platform_dto.freezed.dart
+++ b/lib/dtos/platform_dto.freezed.dart
@@ -1,6 +1,5 @@
-// dart format width=80
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -78,6 +77,130 @@ as String,
 
 }
 
+
+/// Adds pattern-matching-related methods to [PlatformDto].
+extension PlatformDtoPatterns on PlatformDto {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _PlatformDto value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _PlatformDto() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _PlatformDto value)  $default,){
+final _that = this;
+switch (_that) {
+case _PlatformDto():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _PlatformDto value)?  $default,){
+final _that = this;
+switch (_that) {
+case _PlatformDto() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String name,  String url,  String image)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _PlatformDto() when $default != null:
+return $default(_that.id,_that.name,_that.url,_that.image);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String name,  String url,  String image)  $default,) {final _that = this;
+switch (_that) {
+case _PlatformDto():
+return $default(_that.id,_that.name,_that.url,_that.image);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String name,  String url,  String image)?  $default,) {final _that = this;
+switch (_that) {
+case _PlatformDto() when $default != null:
+return $default(_that.id,_that.name,_that.url,_that.image);case _:
+  return null;
+
+}
+}
+
+}
 
 /// @nodoc
 @JsonSerializable()

--- a/lib/dtos/refresh_member_dto.freezed.dart
+++ b/lib/dtos/refresh_member_dto.freezed.dart
@@ -1,6 +1,5 @@
-// dart format width=80
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -106,6 +105,130 @@ $PageableDtoCopyWith<$Res> get followedEpisodes {
 }
 }
 
+
+/// Adds pattern-matching-related methods to [RefreshMemberDto].
+extension RefreshMemberDtoPatterns on RefreshMemberDto {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _RefreshMemberDto value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _RefreshMemberDto() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _RefreshMemberDto value)  $default,){
+final _that = this;
+switch (_that) {
+case _RefreshMemberDto():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _RefreshMemberDto value)?  $default,){
+final _that = this;
+switch (_that) {
+case _RefreshMemberDto() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( PageableDto missedAnimes,  PageableDto followedAnimes,  PageableDto followedEpisodes,  int totalDuration,  int totalUnseenDuration)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _RefreshMemberDto() when $default != null:
+return $default(_that.missedAnimes,_that.followedAnimes,_that.followedEpisodes,_that.totalDuration,_that.totalUnseenDuration);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( PageableDto missedAnimes,  PageableDto followedAnimes,  PageableDto followedEpisodes,  int totalDuration,  int totalUnseenDuration)  $default,) {final _that = this;
+switch (_that) {
+case _RefreshMemberDto():
+return $default(_that.missedAnimes,_that.followedAnimes,_that.followedEpisodes,_that.totalDuration,_that.totalUnseenDuration);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( PageableDto missedAnimes,  PageableDto followedAnimes,  PageableDto followedEpisodes,  int totalDuration,  int totalUnseenDuration)?  $default,) {final _that = this;
+switch (_that) {
+case _RefreshMemberDto() when $default != null:
+return $default(_that.missedAnimes,_that.followedAnimes,_that.followedEpisodes,_that.totalDuration,_that.totalUnseenDuration);case _:
+  return null;
+
+}
+}
+
+}
 
 /// @nodoc
 @JsonSerializable()

--- a/lib/dtos/season_dto.freezed.dart
+++ b/lib/dtos/season_dto.freezed.dart
@@ -1,6 +1,5 @@
-// dart format width=80
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -75,6 +74,130 @@ as int,
 
 }
 
+
+/// Adds pattern-matching-related methods to [SeasonDto].
+extension SeasonDtoPatterns on SeasonDto {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _SeasonDto value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _SeasonDto() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _SeasonDto value)  $default,){
+final _that = this;
+switch (_that) {
+case _SeasonDto():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _SeasonDto value)?  $default,){
+final _that = this;
+switch (_that) {
+case _SeasonDto() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int number)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _SeasonDto() when $default != null:
+return $default(_that.number);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int number)  $default,) {final _that = this;
+switch (_that) {
+case _SeasonDto():
+return $default(_that.number);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int number)?  $default,) {final _that = this;
+switch (_that) {
+case _SeasonDto() when $default != null:
+return $default(_that.number);case _:
+  return null;
+
+}
+}
+
+}
 
 /// @nodoc
 @JsonSerializable()

--- a/lib/dtos/simulcast_dto.freezed.dart
+++ b/lib/dtos/simulcast_dto.freezed.dart
@@ -1,6 +1,5 @@
-// dart format width=80
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -77,6 +76,130 @@ as int,
 
 }
 
+
+/// Adds pattern-matching-related methods to [SimulcastDto].
+extension SimulcastDtoPatterns on SimulcastDto {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _SimulcastDto value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _SimulcastDto() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _SimulcastDto value)  $default,){
+final _that = this;
+switch (_that) {
+case _SimulcastDto():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _SimulcastDto value)?  $default,){
+final _that = this;
+switch (_that) {
+case _SimulcastDto() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String uuid,  String season,  int year)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _SimulcastDto() when $default != null:
+return $default(_that.uuid,_that.season,_that.year);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String uuid,  String season,  int year)  $default,) {final _that = this;
+switch (_that) {
+case _SimulcastDto():
+return $default(_that.uuid,_that.season,_that.year);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String uuid,  String season,  int year)?  $default,) {final _that = this;
+switch (_that) {
+case _SimulcastDto() when $default != null:
+return $default(_that.uuid,_that.season,_that.year);case _:
+  return null;
+
+}
+}
+
+}
 
 /// @nodoc
 @JsonSerializable()

--- a/lib/dtos/week_day_dto.freezed.dart
+++ b/lib/dtos/week_day_dto.freezed.dart
@@ -1,6 +1,5 @@
-// dart format width=80
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -76,6 +75,130 @@ as List<WeekDayReleaseDto>,
 
 }
 
+
+/// Adds pattern-matching-related methods to [WeekDayDto].
+extension WeekDayDtoPatterns on WeekDayDto {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _WeekDayDto value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _WeekDayDto() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _WeekDayDto value)  $default,){
+final _that = this;
+switch (_that) {
+case _WeekDayDto():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _WeekDayDto value)?  $default,){
+final _that = this;
+switch (_that) {
+case _WeekDayDto() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String dayOfWeek,  List<WeekDayReleaseDto> releases)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _WeekDayDto() when $default != null:
+return $default(_that.dayOfWeek,_that.releases);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String dayOfWeek,  List<WeekDayReleaseDto> releases)  $default,) {final _that = this;
+switch (_that) {
+case _WeekDayDto():
+return $default(_that.dayOfWeek,_that.releases);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String dayOfWeek,  List<WeekDayReleaseDto> releases)?  $default,) {final _that = this;
+switch (_that) {
+case _WeekDayDto() when $default != null:
+return $default(_that.dayOfWeek,_that.releases);case _:
+  return null;
+
+}
+}
+
+}
 
 /// @nodoc
 @JsonSerializable()

--- a/lib/dtos/week_day_release_dto.freezed.dart
+++ b/lib/dtos/week_day_release_dto.freezed.dart
@@ -1,6 +1,5 @@
-// dart format width=80
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -93,6 +92,130 @@ $AnimeDtoCopyWith<$Res> get anime {
 }
 }
 
+
+/// Adds pattern-matching-related methods to [WeekDayReleaseDto].
+extension WeekDayReleaseDtoPatterns on WeekDayReleaseDto {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _WeekDayReleaseDto value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _WeekDayReleaseDto() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _WeekDayReleaseDto value)  $default,){
+final _that = this;
+switch (_that) {
+case _WeekDayReleaseDto():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _WeekDayReleaseDto value)?  $default,){
+final _that = this;
+switch (_that) {
+case _WeekDayReleaseDto() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( AnimeDto anime,  List<PlatformDto> platforms,  String releaseDateTime,  String slug,  List<String> langTypes,  String? episodeType,  int? minNumber,  int? maxNumber,  int? number,  List<EpisodeMappingDto>? mappings)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _WeekDayReleaseDto() when $default != null:
+return $default(_that.anime,_that.platforms,_that.releaseDateTime,_that.slug,_that.langTypes,_that.episodeType,_that.minNumber,_that.maxNumber,_that.number,_that.mappings);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( AnimeDto anime,  List<PlatformDto> platforms,  String releaseDateTime,  String slug,  List<String> langTypes,  String? episodeType,  int? minNumber,  int? maxNumber,  int? number,  List<EpisodeMappingDto>? mappings)  $default,) {final _that = this;
+switch (_that) {
+case _WeekDayReleaseDto():
+return $default(_that.anime,_that.platforms,_that.releaseDateTime,_that.slug,_that.langTypes,_that.episodeType,_that.minNumber,_that.maxNumber,_that.number,_that.mappings);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( AnimeDto anime,  List<PlatformDto> platforms,  String releaseDateTime,  String slug,  List<String> langTypes,  String? episodeType,  int? minNumber,  int? maxNumber,  int? number,  List<EpisodeMappingDto>? mappings)?  $default,) {final _that = this;
+switch (_that) {
+case _WeekDayReleaseDto() when $default != null:
+return $default(_that.anime,_that.platforms,_that.releaseDateTime,_that.slug,_that.langTypes,_that.episodeType,_that.minNumber,_that.maxNumber,_that.number,_that.mappings);case _:
+  return null;
+
+}
+}
+
+}
 
 /// @nodoc
 @JsonSerializable()

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -416,5 +416,30 @@
   "later": "Later",
   "@later": {
       "description": "Text for the button to postpone an action."
-  }
+  },
+  "platformPreferences": "Playback Settings",
+  "@platformPreferences": {
+    "description": "Title for the platform preferences dialog or settings option."
+  },
+  "rememberMyChoice": "Remember my choice",
+  "@rememberMyChoice": {
+    "description": "Checkbox label to remember the user's selection."
+  },
+  "dragToReorder": "Drag to reorder",
+  "@dragToReorder": {
+    "description": "Instruction text for reorderable lists."
+  },
+  "continueLabel": "Continue",
+  "@continueLabel": {
+    "description": "Text for a button to continue the action."
+  },
+  "platformPreferencesDescription": "Sort your streaming services (like Netflix, Disney+, etc.) by placing your favorite one first.\n\nThis way, when you play an episode, we'll always suggest that service first and can even open it for you automatically.",
+  "@platformPreferencesDescription": {
+    "description": "Detailed description explaining the screen to reorder preferred platforms."
+  },
+  "reorderPlatforms": "Service Priority",
+  "@reorderPlatforms": {
+    "description": "Settings option label to reorder platforms used when watching episodes."
+  },
+  "reorderPlatformsDescription": "Put your favorite service at the top of the list. We'll prioritize it when you go to watch an episode"
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -105,5 +105,12 @@
   "enableNotifications": "Activer les notifications",
   "notificationsDescription": "Recevez des mises à jour lorsque un nouvel épisode est disponible. Vous pouvez désactiver les notifications à tout moment dans les paramètres",
   "activate": "Activer",
-  "later": "Plus tard"
+  "later": "Plus tard",
+  "platformPreferences": "Préférences de lecture",
+  "rememberMyChoice": "Se souvenir de mon choix",
+  "dragToReorder": "Glissez pour réorganiser",
+  "continueLabel": "Continuer",
+  "platformPreferencesDescription": "Classez vos services de streaming (Netflix, Disney+, etc.) en plaçant votre préféré en premier.\n\nAinsi, quand vous lancerez un épisode, nous vous proposerons toujours ce service en priorité et pourrons même l'ouvrir automatiquement pour vous.",
+  "reorderPlatforms": "Ordre des services",
+  "reorderPlatformsDescription": "Mettez votre service favori en haut de la liste. Nous le lancerons en priorité lorsque vous regarderez un épisode"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -643,6 +643,48 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Later'**
   String get later;
+
+  /// Title for the platform preferences dialog or settings option.
+  ///
+  /// In en, this message translates to:
+  /// **'Playback Settings'**
+  String get platformPreferences;
+
+  /// Checkbox label to remember the user's selection.
+  ///
+  /// In en, this message translates to:
+  /// **'Remember my choice'**
+  String get rememberMyChoice;
+
+  /// Instruction text for reorderable lists.
+  ///
+  /// In en, this message translates to:
+  /// **'Drag to reorder'**
+  String get dragToReorder;
+
+  /// Text for a button to continue the action.
+  ///
+  /// In en, this message translates to:
+  /// **'Continue'**
+  String get continueLabel;
+
+  /// Detailed description explaining the screen to reorder preferred platforms.
+  ///
+  /// In en, this message translates to:
+  /// **'Sort your streaming services (like Netflix, Disney+, etc.) by placing your favorite one first.\n\nThis way, when you play an episode, we\'ll always suggest that service first and can even open it for you automatically.'**
+  String get platformPreferencesDescription;
+
+  /// Settings option label to reorder platforms used when watching episodes.
+  ///
+  /// In en, this message translates to:
+  /// **'Service Priority'**
+  String get reorderPlatforms;
+
+  /// No description provided for @reorderPlatformsDescription.
+  ///
+  /// In en, this message translates to:
+  /// **'Put your favorite service at the top of the list. We\'ll prioritize it when you go to watch an episode'**
+  String get reorderPlatformsDescription;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -357,4 +357,27 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get later => 'Later';
+
+  @override
+  String get platformPreferences => 'Playback Settings';
+
+  @override
+  String get rememberMyChoice => 'Remember my choice';
+
+  @override
+  String get dragToReorder => 'Drag to reorder';
+
+  @override
+  String get continueLabel => 'Continue';
+
+  @override
+  String get platformPreferencesDescription =>
+      'Sort your streaming services (like Netflix, Disney+, etc.) by placing your favorite one first.\n\nThis way, when you play an episode, we\'ll always suggest that service first and can even open it for you automatically.';
+
+  @override
+  String get reorderPlatforms => 'Service Priority';
+
+  @override
+  String get reorderPlatformsDescription =>
+      'Put your favorite service at the top of the list. We\'ll prioritize it when you go to watch an episode';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -362,4 +362,27 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get later => 'Plus tard';
+
+  @override
+  String get platformPreferences => 'Préférences de lecture';
+
+  @override
+  String get rememberMyChoice => 'Se souvenir de mon choix';
+
+  @override
+  String get dragToReorder => 'Glissez pour réorganiser';
+
+  @override
+  String get continueLabel => 'Continuer';
+
+  @override
+  String get platformPreferencesDescription =>
+      'Classez vos services de streaming (Netflix, Disney+, etc.) en plaçant votre préféré en premier.\n\nAinsi, quand vous lancerez un épisode, nous vous proposerons toujours ce service en priorité et pourrons même l\'ouvrir automatiquement pour vous.';
+
+  @override
+  String get reorderPlatforms => 'Ordre des services';
+
+  @override
+  String get reorderPlatformsDescription =>
+      'Mettez votre service favori en haut de la liste. Nous le lancerons en priorité lorsque vous regarderez un épisode';
 }

--- a/lib/views/account_settings_view.dart
+++ b/lib/views/account_settings_view.dart
@@ -1,6 +1,7 @@
 import 'package:application/components/card_component.dart';
 import 'package:application/controllers/member_controller.dart';
 import 'package:application/controllers/notifications_controller.dart';
+import 'package:application/controllers/platforms_controller.dart';
 import 'package:application/controllers/sort_controller.dart';
 import 'package:application/controllers/vibration_controller.dart';
 import 'package:application/dtos/member_dto.dart';
@@ -233,6 +234,30 @@ class AccountSettingsView extends StatelessWidget {
                                 )
                                 .toList(),
                           ),
+                    ),
+                  ],
+                ),
+                SettingsCategory(
+                  icon: Icons.live_tv_outlined,
+                  title: appLocalizations.platformPreferences,
+                  options: <Widget>[
+                    SettingsOption(
+                      title: appLocalizations.reorderPlatforms,
+                      subtitle: appLocalizations.reorderPlatformsDescription,
+                      onTap: () async {
+                        await PlatformsController.instance.init();
+
+                        if (!context.mounted) {
+                          return;
+                        }
+
+                        await PlatformsController.instance
+                            .managePlatformPreferences(
+                              context,
+                              PlatformsController.instance.items,
+                              isForSettings: true,
+                            );
+                      },
                     ),
                   ],
                 ),


### PR DESCRIPTION
Added `PlatformPreferenceDialog` for users to reorder and save their streaming platform preferences. Implemented `PlatformsController` to manage platform sorting and preferences. Extended localization files with new strings for `Playback Settings`. Refactored relevant components to accommodate variable platform dimensions and utilize stored preferences for ordering platforms.